### PR TITLE
[chore] IchikabuAPI 単体解決の Package.resolved を無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ xcuserdata/
 .build/
 DerivedData/
 ios/build/
+
+# IchikabuAPI をパッケージ単体で解決したときに出る依存の固定ファイル。
+# アプリのビルドが使うのは Ichikabu.xcodeproj 側の Package.resolved で、
+# 中身（pins）は同じになるため、2箇所で管理してズレるのを防ぐ
+ios/IchikabuAPI/Package.resolved


### PR DESCRIPTION
## 概要

`ios/IchikabuAPI/Package.resolved` が未追跡ファイルとして残っていたため、`.gitignore` に追加した。

## 理由

`Package.resolved` はリポジトリ内に2つある。

| ファイル | 状態 | 使われ方 |
|---|---|---|
| `ios/Ichikabu.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` | コミット済み | アプリのビルド（品質ゲートの `xcodebuild`）が使う |
| `ios/IchikabuAPI/Package.resolved` | 未追跡 | パッケージ単体で解決したときに出る副産物 |

両者の pins（依存の固定バージョン）は完全に一致していて、違うのは `originHash`（どのマニフェストを起点に解決したかのハッシュ）だけ。コミットすると同じ内容を2箇所で管理することになり、片方だけ更新されてズレる。

## 確認

- `git check-ignore -v ios/IchikabuAPI/Package.resolved` で無視されることを確認
- `git status` がクリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bt7dswJrwpz4JFWvnZzZhC