### PR TITLE
[feat] FOMC の日程を開発用データに入れる

### DIFF
--- a/server/src/db/seed-event.ts
+++ b/server/src/db/seed-event.ts
@@ -5,9 +5,10 @@ import { event, holding, stock } from "./schema";
 /**
  * 開発中の表示確認に使うデータ（Issue #8 設計書 §3）。
  *
- * 日付の出典は各社のIRページだけを使う（全体設計書 §5.1）ため、
- * 入れられるのは銘柄イベント（決算発表日）だけになる。市場イベント・
- * テーマイベントは、使ってよい出典が増えるまで入れられない。
+ * 入れられるのは、全体設計書 §5.1 の表で「使う」になっている出典で日付を
+ * 確認できるものだけになる。今は各社のIRページ（銘柄イベント）と FRB
+ * （FOMC の市場イベント）の2つ。テーマイベントは、テーマ固有の出来事の
+ * 出典がまだ無いため入れられない。
  */
 const STOCKS = [
   { market: "JP", ticker: "7203", name: "トヨタ自動車", fiscalMonth: 3 },
@@ -50,6 +51,96 @@ const EVENTS = [
 ] as const;
 
 /**
+ * FOMC の政策金利発表。出典は FRB で、条件は出所の記載だけ（全体設計書 §5.1）。
+ *
+ * 声明は会合2日目の米東部時間 14:00 に出る。日付・時刻はJSTで入れるため
+ * （設計書 §4.1）、夏時間の期間は翌日 3:00、冬時間は翌日 4:00 になる。下の値は
+ * IANAのタイムゾーンデータで換算したもので、目視で足したものではない。
+ *
+ * 会合は現地で2日間あるが、単日で入れる。利用者に効くのは声明が出る1点で、
+ * 初日をカレンダーに出すと1日2件のセル枠を1つ食う（設計書 §10.2）。現地の
+ * 会合日は `note` に残す。
+ *
+ * 掲載は2027年12月まで（FRB のカレンダー）。それ以降は読み直して足す。
+ */
+const MARKET_EVENTS = [
+  {
+    title: "FOMC 政策金利発表（2026年9月）",
+    startDate: "2026-09-17",
+    time: "03:00",
+    note: "会合は現地時間9月15〜16日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2026年10月）",
+    startDate: "2026-10-29",
+    time: "03:00",
+    note: "会合は現地時間10月27〜28日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2026年12月）",
+    startDate: "2026-12-10",
+    time: "04:00",
+    note: "会合は現地時間12月8〜9日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年1月）",
+    startDate: "2027-01-28",
+    time: "04:00",
+    note: "会合は現地時間1月26〜27日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年3月）",
+    startDate: "2027-03-18",
+    time: "03:00",
+    note: "会合は現地時間3月16〜17日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年4月）",
+    startDate: "2027-04-29",
+    time: "03:00",
+    note: "会合は現地時間4月27〜28日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年6月）",
+    startDate: "2027-06-10",
+    time: "03:00",
+    note: "会合は現地時間6月8〜9日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年7月）",
+    startDate: "2027-07-29",
+    time: "03:00",
+    note: "会合は現地時間7月27〜28日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年9月）",
+    startDate: "2027-09-16",
+    time: "03:00",
+    note: "会合は現地時間9月14〜15日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年10月）",
+    startDate: "2027-10-28",
+    time: "03:00",
+    note: "会合は現地時間10月26〜27日。日本時間の発表時刻",
+  },
+  {
+    title: "FOMC 政策金利発表（2027年12月）",
+    startDate: "2027-12-09",
+    time: "04:00",
+    note: "会合は現地時間12月7〜8日。日本時間の発表時刻",
+  },
+].map((e) => ({
+  ...e,
+  shortLabel: "FOMC",
+  importance: 3,
+  // 日本株にも効くため US ではなく GLOBAL（設計書 §4.2）
+  market: "GLOBAL" as const,
+  sourceName: "Federal Reserve Board",
+  sourceUrl: "https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm",
+}));
+
+/**
  * 銘柄・保有・イベントを投入する。何度実行しても増えない。
  * 銘柄と保有は一意の制約があるので衝突を無視し、
  * イベントには一意の制約が無いため、見出しで既にあるかを判定する。
@@ -85,12 +176,12 @@ export async function seedEvents(userId: string): Promise<{ created: number }> {
     .where(
       inArray(
         event.title,
-        EVENTS.map((e) => e.title),
+        [...EVENTS, ...MARKET_EVENTS].map((e) => e.title),
       ),
     );
   const have = new Set(existing.map((row) => row.title));
 
-  const missing = EVENTS.filter((e) => !have.has(e.title)).map(
+  const missingStockEvents = EVENTS.filter((e) => !have.has(e.title)).map(
     ({ ticker, ...rest }) => {
       const stockId = stockIdOf.get(ticker);
       // 直前に投入しているので通常は起きない。握りつぶすと
@@ -101,6 +192,15 @@ export async function seedEvents(userId: string): Promise<{ created: number }> {
       return { ...rest, stockId };
     },
   );
-  if (missing.length > 0) await db.insert(event).values(missing);
-  return { created: missing.length };
+  const missingMarketEvents = MARKET_EVENTS.filter((e) => !have.has(e.title));
+
+  // 銘柄イベントは stock_id、市場イベントは market を入れる。列が違うので
+  // 1回の insert にまとめず、それぞれの形のまま投入する
+  if (missingStockEvents.length > 0) {
+    await db.insert(event).values(missingStockEvents);
+  }
+  if (missingMarketEvents.length > 0) {
+    await db.insert(event).values(missingMarketEvents);
+  }
+  return { created: missingStockEvents.length + missingMarketEvents.length };
 }


### PR DESCRIPTION
Closes #53

## 変更内容

PR #52 で FRB を出典として使えるようにした、その最初の登録。`server/src/db/seed-event.ts` に FOMC の政策金利発表を11件（2026年9月〜2027年12月）入れた。**seed が市場イベント（`market = 'GLOBAL'`）を持つのは初めて**で、これまでは銘柄イベントしか入れられなかった。

| 項目 | 値 |
|---|---|
| 対象 | `market = 'GLOBAL'`（日本株にも効くため US ではない。設計書 §4.2） |
| 日付 | 声明発表のJST。会合2日目の米東部時間14時 → 翌日3時（夏時間）・4時（冬時間） |
| 期間 | 単日。会合は現地で2日間あるが、初日を出すと1日2件のセル枠を1つ食う（§10.2）。現地の会合日は `note` に残した |
| 出典 | `Federal Reserve Board` ＋ FOMC カレンダーのURL |
| 重要度 | 3 |

日本時間への換算は目視で足さず、IANAのタイムゾーンデータ（Pythonの `zoneinfo`）で行った。夏時間・冬時間の切り替わりが2026年12月と2027年1月・12月に効いている（そこだけ4時）。

## 検証

Issue #53 の受け入れ条件どおり、`pnpm db:seed` 後に11件が入る。

\`\`\`
$ docker compose exec -T db psql -U postgres -d ichikabu -c "SELECT start_date, time, short_label, market FROM event WHERE market IS NOT NULL ORDER BY start_date;"
 start_date |   time   | short_label | market
------------+----------+-------------+--------
 2026-09-17 | 03:00:00 | FOMC        | GLOBAL
 2026-10-29 | 03:00:00 | FOMC        | GLOBAL
 2026-12-10 | 04:00:00 | FOMC        | GLOBAL
 2027-01-28 | 04:00:00 | FOMC        | GLOBAL
 2027-03-18 | 03:00:00 | FOMC        | GLOBAL
 2027-04-29 | 03:00:00 | FOMC        | GLOBAL
 2027-06-10 | 03:00:00 | FOMC        | GLOBAL
 2027-07-29 | 03:00:00 | FOMC        | GLOBAL
 2027-09-16 | 03:00:00 | FOMC        | GLOBAL
 2027-10-28 | 03:00:00 | FOMC        | GLOBAL
 2027-12-09 | 04:00:00 | FOMC        | GLOBAL
(11 rows)
\`\`\`

2回続けて実行しても増えない（「何度実行しても増えない」性質を保っている）。

\`\`\`
$ pnpm db:seed
イベントを 0 件作成した
$ psql ... -tAc "SELECT count(*) FROM event WHERE market IS NOT NULL;"
11
\`\`\`

品質ゲート（`server/`）は全パス。

\`\`\`
build OK
 Test Files  7 passed (7)
      Tests  117 passed (117)
Checked 47 files in 48ms. No fixes applied.
\`\`\`

iOS 側のゲート（`xcodebuild`）は実行していない。`openapi.yaml` と `ios/` に触れておらず、変更が server の投入データだけのため。

## 残っていること（このPRの外）

- **2028年以降**。FRB の掲載は2027年12月まで。来年また読み直して足す（`MARKET_EVENTS` のコメントに書いた）
- **BLS（米CPI・米雇用統計）**。出典は1つずつ増やす決まりなので、必要になったら別 Issue で条件を読む

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U5xNFrZu9e4xox5bVzt1x