### PR TITLE
[docs] 取得が禁じられていないことの根拠を原文で残す

### DIFF
--- a/docs/reference/source-terms.md
+++ b/docs/reference/source-terms.md
@@ -102,10 +102,10 @@
 
 `http_code=200 size=39 content_type=text/plain`
 
-````
+```
 User-agent: *
 Disallow: /library/opac/
-````
+```
 
 これで全文（末尾に改行が無いため39バイト）。**公表予定の置き場（`/data/kouhyou/`）は `Disallow` に入っていない。**
 
@@ -119,11 +119,11 @@ Disallow: /library/opac/
 
 `http_code=200 size=72 content_type=text/plain`
 
-````
+```
 User-agent:*
 Disallow:
 Sitemap:https://www.customs.go.jp/sitemap_00.xml
-````
+```
 
 これで全文。`Disallow:` の右が空なので、禁止しているパスは無い。
 

--- a/docs/reference/source-terms.md
+++ b/docs/reference/source-terms.md
@@ -95,10 +95,39 @@
 | 項目 | 内容 |
 |---|---|
 | 確認日 | 2026-08-12 |
-| 確認したこと | 各サイトの `robots.txt` |
-| `www.stat.go.jp` | `User-agent: *` と `Disallow: /library/opac/` の2行だけ。**公表予定の置き場（`/data/kouhyou/`）は対象外** |
-| `www.esri.cao.go.jp` | **`robots.txt` が無い**（HTTP 404） |
-| `www.customs.go.jp` | `Disallow:` が空＝全許可。`Sitemap:` も公開している |
+| 確認したこと | 各サイトの `robots.txt` を取得した |
+| 取得方法 | `curl -sS -w "http_code=%{http_code} size=%{size_download} content_type=%{content_type}"`。**下に貼ったのは返ってきたものそのもので、要約していない** |
+
+#### `https://www.stat.go.jp/robots.txt`
+
+`http_code=200 size=39 content_type=text/plain`
+
+````
+User-agent: *
+Disallow: /library/opac/
+````
+
+これで全文（末尾に改行が無いため39バイト）。**公表予定の置き場（`/data/kouhyou/`）は `Disallow` に入っていない。**
+
+#### `https://www.esri.cao.go.jp/robots.txt`
+
+`http_code=404 size=5646 content_type=text/html`
+
+**`robots.txt` は置かれていない。** 返ってきたのは内閣府の一般的な404ページで、`<title>404 Not Found - 内閣府</title>` と「指定されたページまたはファイルは存在しません。」が入っている。**方針が書かれたページではない。** BLS が 403 とともに方針文のページを返したのとは違う（→ 下記）。
+
+#### `https://www.customs.go.jp/robots.txt`
+
+`http_code=200 size=72 content_type=text/plain`
+
+````
+User-agent:*
+Disallow:
+Sitemap:https://www.customs.go.jp/sitemap_00.xml
+````
+
+これで全文。`Disallow:` の右が空なので、禁止しているパスは無い。
+
+#### 読み取ったこと
 
 **3つとも、取得を禁じる記述が見当たらなかった。** BLS（下記）とは正反対である。この結果を根拠に、全体設計書 §2.1 が「配信されている構造化データを読むのは可」と決めている。
 
@@ -202,6 +231,6 @@
 | 見るもの | どこ |
 |---|---|
 | 公表予定の配信の有無（形・掲載期間・公表時刻） | 日本の府省は「公表予定の配信」の節。FRB は「読み取った条件」の表の「日程の掲載場所」の欄、BLS は同じ表の「機械で読める形」の欄 |
-| プログラムからの取得の可否（`robots.txt` と利用条件） | 「プログラムからの取得」の節（日本の府省・FRB・BLS の3つの節すべてにある） |
+| プログラムからの取得の可否（`robots.txt` と利用条件） | 「プログラムからの取得」の節（日本の府省・FRB・BLS の3つの節すべてにある）。**`robots.txt` は取り直して、貼ってある原文とそのまま見比べる** |
 
 変わっていたら、全体設計書 §5.1 の表だけでなく **§2.1 の当てはめ表**も直す。特に `robots.txt` は後から足されることがあり、今「無い」ものが「ある」に変わりうる。


### PR DESCRIPTION
Closes #65

## 変更内容

`docs/reference/source-terms.md`（出典の条文を**原文のまま**残すファイル）の「日本の府省」の節で、「プログラムからの取得を禁じていない」の根拠が要約しか残っていなかったのを、**取得した `robots.txt` の原文と HTTP ステータス**に置き換えた。

| | 直す前 | 直した後 |
|---|---|---|
| `www.stat.go.jp` | 「`User-agent: *` と `Disallow: /library/opac/` の2行だけ」（要約） | 原文のコードブロック＋`http_code=200 size=39 content_type=text/plain` |
| `www.esri.cao.go.jp` | 「`robots.txt` が無い（HTTP 404）」 | `http_code=404 size=5646 content_type=text/html`＋返ってきたのが内閣府の一般的な404ページであること |
| `www.customs.go.jp` | 「`Disallow:` が空＝全許可」（要約） | 原文のコードブロック＋`http_code=200 size=72 content_type=text/plain` |

## なぜ直したか

全体設計書 §2.1（[PR #63](https://github.com/TakuyaAsaoka/ichikabu/pull/63)）が「配信されている構造化データを読むのは可」と決めた根拠が、この節の記録である。**その一番大事なところが要約だった。**

BLS（禁止側）は方針文の原文と HTTP 403 が残っているのに、禁じていない側は要約しか無く、確からしさが釣り合っていなかった。`robots.txt` は数行しかないので、要約せずそのまま置ける。

内閣府の 404 については、**それが「置いていない」ことしか示さない**という限界も書いた。BLS が 403 とともに方針文のページを返したのとは違う。

## 更新の手順も直した

`robots.txt` は後から足されることがある。「取り直して、貼ってある原文とそのまま見比べる」を更新手順に足した。原文が残っていれば差分で気づける。

## 検証

Issue #65 の「あるべき姿の出力」と一致した。

```
$ grep -c "User-agent" docs/reference/source-terms.md; grep -c "http_code" docs/reference/source-terms.md
2
4
```

`jargon-lint.sh --audit` は0件。**`server` と `ios` の品質ゲートは流していない**（変更が `docs/` だけのため。PR #58・#63 と同じ扱い）。

## レビューで直したこと

Critical・Important は0件。**レビュー担当が3サイトすべてを自分で `curl` で取り直し、貼った原文・`http_code`・`size`・`content_type` がバイト単位で一致することを確かめた。** 内閣府の404ページも一致。

Minor 1件（コードブロックのバッククォートが4つで、他の箇所と揃っていない）を直した。**直さずに残した指摘は無い。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2r9kDnLxUo7rAjoreSR4H