### PR TITLE
[feat] 管理UIのログインを Google の認証に切り替える (#77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ xcodebuild build test -scheme Ichikabu -destination 'platform=iOS Simulator,name
 cp .env.example .env.local
 # BETTER_AUTH_SECRET に `openssl rand -base64 32` の出力を入れる
 # SEED_USER_EMAIL / SEED_USER_PASSWORD を埋める
+# GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET を埋める（未設定だとサーバーが起動時に落ちる）。
+#   Google でのログインを実際に試さないなら、品質ゲートを回すだけなら任意の文字列でよい。
+#   本物の値の取り方は docs/guides/google-oauth.md
 nvm use
 docker compose up -d --wait
 pnpm install && pnpm db:migrate && pnpm db:seed

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -72,8 +72,10 @@ curl https://ichikabu.netlify.app/api/health
 | `DATABASE_URL` | 要る | 要る | **入口が違う。下の §4 を参照** |
 | `BETTER_AUTH_SECRET` | 要る | 要る | `openssl rand -base64 32`。開発用とは別の値 |
 | `BETTER_AUTH_URL` | 要る | 要らない | `https://ichikabu.netlify.app` |
-| `SEED_USER_EMAIL` | 要らない | 要る | サインインに使うメールアドレス |
-| `SEED_USER_PASSWORD` | 要らない | 要る | サインインに使うパスワード |
+| `GOOGLE_CLIENT_ID` | 要る | 要らない | 取得は `docs/guides/google-oauth.md`。`pnpm db:seed` は `.env.local` 側の値で足りる |
+| `GOOGLE_CLIENT_SECRET` | 要る | 要らない | 同上 |
+| `SEED_USER_EMAIL` | 要らない | 要る | サインインに使うメールアドレス。**Google でログインするアカウントと同じにする** |
+| `SEED_USER_PASSWORD` | 要らない | 要る | サインインに使うパスワード。iOS が使うので消さない |
 
 Netlify 側は Project configuration > Environment variables に入れる。
 

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -1,0 +1,118 @@
+# 管理UIの Google でのログイン
+
+管理UI（`https://ichikabu.netlify.app` と `http://localhost:3000`）に Google アカウントでログインするための設定手順。
+
+iOS アプリはこの経路を使わない。iOS は今までどおりメールアドレスとパスワードで
+`POST /api/auth/sign-in/email` を叩く（設計書 §9）。
+
+## 入れる人は1人だけ
+
+**このアプリの利用者は1人で、新しい利用者を作る経路は無い**（設計書 §9）。
+Google でログインできるのは、`pnpm db:seed` で入れた利用者と**同じメールアドレス**の
+Google アカウントだけ。他のアカウントは、DBに利用者が居ないので拒まれる。
+
+許可するメールアドレスの一覧は持たない。DBの利用者がそのまま「入れてよい人」になる。
+
+## 1. Google Cloud Console でクライアントIDを作る
+
+1. https://console.cloud.google.com/ を開く
+2. 上部のプロジェクト選択メニュー → **新しいプロジェクト**（既にあるものを使ってもよい）
+3. 左メニュー → **APIとサービス** → **OAuth同意画面**
+   - **アプリ名**: `イチカブ`（任意）
+   - **ユーザーサポートメール**: 自分のメールアドレス
+   - **対象**: **外部**（個人の Google アカウントを使うため）
+   - **連絡先メールアドレス**: 自分のメールアドレス
+4. 「外部」にするとアプリは**テスト中**になる。**テストユーザーに自分のメールアドレスを追加する**。
+   追加しないと同意画面が「アクセスをブロックしました」で止まる
+5. 左メニュー → **APIとサービス** → **認証情報** → **＋認証情報を作成** → **OAuthクライアントID**
+   - **アプリケーションの種類**: ウェブアプリケーション
+   - **名前**: `ichikabu-web`（任意）
+   - **承認済みのJavaScript生成元**:
+     - `http://localhost:3000`
+     - `https://ichikabu.netlify.app`
+   - **承認済みのリダイレクトURI**:
+     - `http://localhost:3000/api/auth/callback/google`
+     - `https://ichikabu.netlify.app/api/auth/callback/google`
+6. **クライアントID** と **クライアントシークレット** を控える
+
+**リダイレクトURIは完全一致で照合される。** 末尾のスラッシュの有無も違いになる。
+
+## 2. 手元（`localhost:3000`）に設定する
+
+`server/.env.local` に2行入れる。
+
+```
+GOOGLE_CLIENT_ID=<手順1のクライアントID>
+GOOGLE_CLIENT_SECRET=<手順1のクライアントシークレット>
+```
+
+**開発中も Google の認証を通す。** 配信先だけで使う状態にすると、毎日踏まない経路になり、
+壊れたことに配信先で初めて気づく。
+
+### 未設定だと起動時に落ちる
+
+`server/src/auth.ts` は、この2つが無いと例外を投げてサーバーを起動させない。
+
+Better Auth は未設定でも警告を1行出すだけでプロバイダを登録する。その状態のまま
+「Google でログイン」を押すと、**本文の無い HTTP 500** が返る。画面には応答コードしか出ず、
+設定漏れなのか実装の不具合なのか区別がつかない。起動時に落とすほうが分かる。
+
+## 3. 配信先（Netlify）に設定する
+
+Netlify の **Project configuration > Environment variables** に同じ2つを入れる
+（`docs/guides/deploy.md` §2 の表）。
+
+入れ忘れると、デプロイ後に管理UIの「Google でログイン」が 500 を返す。
+**そのときはメールアドレスとパスワードでログインできる。** サインイン画面には
+両方の入り口が残してある。
+
+## 4. 確認
+
+開発サーバー（`cd server && nvm use && pnpm dev`）を起動して、リポジトリの最上位で実行する。
+
+```bash
+curl -s -X POST http://localhost:3000/api/auth/sign-in/social \
+  -H "content-type: application/json" \
+  -d '{"provider":"google","callbackURL":"/"}'
+```
+
+`https://accounts.google.com/o/oauth2/...` から始まり `client_id=` を含むURLが返れば設定できている。
+
+```
+{"url":"https://accounts.google.com/o/oauth2/auth?client_id=...","redirect":true}
+```
+
+| 返ってくるもの | 原因 |
+|---|---|
+| `{"code":"PROVIDER_NOT_FOUND"}`・404 | `server/src/auth.ts` に `socialProviders` が無い |
+| 本文の無い 500 | `GOOGLE_CLIENT_ID` か `GOOGLE_CLIENT_SECRET` が空（配信先で起きる。手元は起動時に落ちる） |
+
+## 5. 仕組み
+
+`server/src/auth.ts` に3つ書いてある。
+
+| 設定 | 何のため |
+|---|---|
+| `socialProviders.google` | クライアントIDとシークレットを渡すだけ |
+| `databaseHooks.user.create.before` で必ず例外を投げる | **利用者を増やす作成を全部拒む。** 許可していない Google アカウントの利用者がDBに作られないのはこれによる |
+| （`accountLinking` は書かない） | 既定が最も厳しい。同じメールアドレスで、Google 側もDB側もメール確認済みのときだけ結びつく |
+
+### なぜ `disableSignUp` ではなく DB のフックなのか
+
+Better Auth 1.6.26 には、プロバイダ側の `disableSignUp: true` が効かない経路がある。
+
+- `/api/auth/callback/google`（同意画面からの戻り）は `provider.options.disableSignUp` を見る → 効く
+- `/api/auth/sign-in/social` に ID トークンを直接渡す経路は `provider.disableSignUp` を見る → **効かない**
+
+設定から上がってくるのは前者だけ（`create-context.mjs:103` が `disableImplicitSignUp` しか
+コピーしない）。後者の経路は素通りして利用者が作られる。
+
+経路ごとに塞ぐのをやめ、**どの経路も必ず通る `internalAdapter.createOAuthUser` の手前**で
+止めている。この関門が効いていることは `server/src/auth.test.ts` の
+「許可していない Google アカウントでは利用者が作られない」で確かめられる。
+フックの `throw` を消すと、このテストが `intruder@example.com` の作成を検出して失敗する。
+
+### seed だけが利用者を作れる
+
+`server/src/db/seed-user.ts` は、このフックを通らないようテーブルへ直接 `insert` する。
+**利用者を作れる唯一の経路がこのスクリプト**という形にしてある。

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -99,16 +99,11 @@ curl -s -X POST http://localhost:3000/api/auth/sign-in/social \
 
 ### なぜ `disableSignUp` ではなく DB のフックなのか
 
-Better Auth 1.6.26 には、プロバイダ側の `disableSignUp: true` が効かない経路がある。
+プロバイダ側の `disableSignUp: true` には、Better Auth 1.6.26 で効かない経路がある。
+**理由は `server/src/auth.ts` のコメントに書いてある**（ライブラリを上げたときに読む場所を
+2つにしないため、ここには写さない）。
 
-- `/api/auth/callback/google`（同意画面からの戻り）は `provider.options.disableSignUp` を見る → 効く
-- `/api/auth/sign-in/social` に ID トークンを直接渡す経路は `provider.disableSignUp` を見る → **効かない**
-
-設定から上がってくるのは前者だけ（`create-context.mjs:103` が `disableImplicitSignUp` しか
-コピーしない）。後者の経路は素通りして利用者が作られる。
-
-経路ごとに塞ぐのをやめ、**どの経路も必ず通る `internalAdapter.createOAuthUser` の手前**で
-止めている。この関門が効いていることは `server/src/auth.test.ts` の
+関門が効いていることは `server/src/auth.test.ts` の
 「許可していない Google アカウントでは利用者が作られない」で確かめられる。
 フックの `throw` を消すと、このテストが `intruder@example.com` の作成を検出して失敗する。
 

--- a/docs/records/specs/2026-08-02-1-ichikabu-design.md
+++ b/docs/records/specs/2026-08-02-1-ichikabu-design.md
@@ -347,13 +347,16 @@ Better Auth 一本で両クライアントをまかなう。
 
 | クライアント | 方式 |
 |---|---|
-| Web管理UI | Cookieセッション |
-| iOS | Bearerプラグイン + Keychain保存 |
+| Web管理UI | Cookieセッション。Google でのログインとメール＋パスワードの両方（→ `docs/guides/google-oauth.md`） |
+| iOS | Bearerプラグイン + Keychain保存。メール＋パスワードのみ |
 
 - **`user` テーブルは自作しない。Better Auth が生成するものをそのまま本設計の `user` とし、`holding` はそれを参照する**（未決事項 #9 の決定）
   - 根拠: `user` は全FKのハブである。別テーブルで作って後から統合すると `holding` 等のFK張り替えとデータ移行が発生するが、今なら判断1つで済む。利用者1人で属性を足す予定もない段階では、テーブルが1枚少ない構成が素直
   - 引き換えに、Better Auth のスキーマ都合（列名・マイグレーション）に本設計のFKが縛られる。これは受け入れる
-- サインアップ無効（`disableSignUp`）。ユーザーは1件を手動投入
+- サインアップ無効。ユーザーは1件を手動投入。**利用者を作れるのは `pnpm db:seed` だけ**で、
+  Better Auth を通る作成（メール＋パスワードのサインアップ、Google の初回サインイン）は
+  `databaseHooks.user.create.before` が全部拒む。プロバイダごとの `disableSignUp` では
+  塞ぎきれない経路があるため（→ `docs/guides/google-oauth.md`）
 - **Better Auth が生成する4テーブルの日時列はタイムゾーンなし**（自前テーブルの `created_at` はタイムゾーン付き）。生成物のため合わせに行かない。`session.expires_at` の解釈がサーバーのタイムゾーン設定に依存する点だけ、ホスティング先を選ぶとき（Issue #16）に確認する
 - SwiftにSDKは不要。サインインは `POST /api/auth/sign-in/email` を叩くだけ
 - リフレッシュ機構なし。セッションはスライディング延長され、401が返ったら再ログイン画面に落とす（→ §7）

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,7 +8,14 @@ TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5434/ichikabu_test
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3000
 
-# seed スクリプトが作る唯一のユーザー（設計書 §9「ユーザーは1件を手動投入」）
+# 管理UIの「Google でログイン」。取得の手順は docs/guides/google-oauth.md。
+# 未設定だとサーバーが起動時に落ちる
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# seed スクリプトが作る唯一のユーザー（設計書 §9「ユーザーは1件を手動投入」）。
+# Google でログインするときは、この SEED_USER_EMAIL と同じメールアドレスの
+# Google アカウントを使う。違うアドレスは、DBに利用者が無いので入れない
 SEED_USER_EMAIL=
 SEED_USER_PASSWORD=
 

--- a/server/app/signin/page.tsx
+++ b/server/app/signin/page.tsx
@@ -4,15 +4,29 @@ import { auth } from "../../src/auth";
 import { SignInForm } from "./signin-form";
 
 /** サインイン画面。サインイン済みで開いたら管理画面へ戻す */
-export default async function SignInPage() {
+export default async function SignInPage({
+  searchParams,
+}: {
+  // Google の認証が失敗すると errorCallbackURL（この画面）に error 付きで戻ってくる
+  searchParams: Promise<{ error?: string }>;
+}) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (session) {
     redirect("/");
   }
 
+  const { error } = await searchParams;
+
   return (
     <>
       <h1 className="text-xl font-bold">イチカブ 管理</h1>
+      {error && (
+        <p className="text-error">
+          {error === "signup_disabled"
+            ? "この Google アカウントではログインできません"
+            : `Google でのログインに失敗しました（${error}）`}
+        </p>
+      )}
       <SignInForm />
     </>
   );

--- a/server/app/signin/page.tsx
+++ b/server/app/signin/page.tsx
@@ -7,8 +7,9 @@ import { SignInForm } from "./signin-form";
 export default async function SignInPage({
   searchParams,
 }: {
-  // Google の認証が失敗すると errorCallbackURL（この画面）に error 付きで戻ってくる
-  searchParams: Promise<{ error?: string }>;
+  // Google の認証が失敗すると errorCallbackURL（この画面）に error 付きで戻ってくる。
+  // 同じキーが2回来ると配列になるため、文字列だけとは限らない
+  searchParams: Promise<{ error?: string | string[] }>;
 }) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (session) {
@@ -21,10 +22,12 @@ export default async function SignInPage({
     <>
       <h1 className="text-xl font-bold">イチカブ 管理</h1>
       {error && (
+        // 中身は画面に出さない。URLに入れた文字列がそのまま出ると、
+        // このアドレスを開かせるだけで偽の案内文をログイン画面に載せられる
         <p className="text-error">
           {error === "signup_disabled"
             ? "この Google アカウントではログインできません"
-            : `Google でのログインに失敗しました（${error}）`}
+            : "Google でのログインに失敗しました"}
         </p>
       )}
       <SignInForm />

--- a/server/app/signin/signin-form.tsx
+++ b/server/app/signin/signin-form.tsx
@@ -21,6 +21,30 @@ export function SignInForm() {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
+  async function handleGoogle() {
+    setPending(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/auth/sign-in/social", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "google", callbackURL: "/" }),
+      });
+      const body: { url?: string } = await response.json();
+      if (!response.ok || !body.url) {
+        setPending(false);
+        setError(messageFor(response.status));
+        return;
+      }
+      // Google の同意画面へ移る。戻り先は /api/auth/callback/google
+      window.location.assign(body.url);
+    } catch {
+      setPending(false);
+      setError("通信に失敗しました。もう一度試してください");
+    }
+  }
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     // event.currentTarget は await をまたぐと null になるため、先に読む
@@ -59,6 +83,17 @@ export function SignInForm() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <button
+        type="button"
+        onClick={handleGoogle}
+        disabled={pending}
+        className="rounded border border-border p-2 disabled:opacity-50"
+      >
+        Google でログイン
+      </button>
+      {/* メールアドレスとパスワードは iOS が使う経路と同じもの。
+          Google の設定が壊れた日に管理UIへ入る手段として残す */}
+      <p className="text-center">または</p>
       <label className="flex flex-col gap-1">
         メールアドレス
         <input

--- a/server/app/signin/signin-form.tsx
+++ b/server/app/signin/signin-form.tsx
@@ -32,8 +32,9 @@ export function SignInForm() {
         body: JSON.stringify({
           provider: "google",
           callbackURL: "/",
-          // 既定の戻り先は Better Auth の /error で、そこから / へ飛ばされ、
-          // セッションが無いので何も出ないままこの画面に戻ってくる。
+          // 既定の戻り先は Better Auth の /error。本番ではそこから / へ飛ばされ、
+          // セッションが無いので何も出ないままこの画面に戻ってくる（開発中は
+          // ライブラリの英語のエラーページが出る）。
           // 許可していないアカウントで押したときに理由を出すため、自分で受ける
           errorCallbackURL: "/signin",
         }),
@@ -48,7 +49,7 @@ export function SignInForm() {
       const body: { url?: string } = await response.json();
       if (!body.url) {
         setPending(false);
-        setError(messageFor(response.status));
+        setError("Google のログインURLを取得できませんでした");
         return;
       }
       // Google の同意画面へ移る。戻り先は /api/auth/callback/google

--- a/server/app/signin/signin-form.tsx
+++ b/server/app/signin/signin-form.tsx
@@ -29,10 +29,24 @@ export function SignInForm() {
       const response = await fetch("/api/auth/sign-in/social", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: "google", callbackURL: "/" }),
+        body: JSON.stringify({
+          provider: "google",
+          callbackURL: "/",
+          // 既定の戻り先は Better Auth の /error で、そこから / へ飛ばされ、
+          // セッションが無いので何も出ないままこの画面に戻ってくる。
+          // 許可していないアカウントで押したときに理由を出すため、自分で受ける
+          errorCallbackURL: "/signin",
+        }),
       });
+      // 本文より先に応答コードを見る。設定漏れのときは本文の無い 500 が返り、
+      // json() が例外になって「通信に失敗しました」に化ける
+      if (!response.ok) {
+        setPending(false);
+        setError(messageFor(response.status));
+        return;
+      }
       const body: { url?: string } = await response.json();
-      if (!response.ok || !body.url) {
+      if (!body.url) {
         setPending(false);
         setError(messageFor(response.status));
         return;

--- a/server/src/auth.test.ts
+++ b/server/src/auth.test.ts
@@ -44,6 +44,24 @@ describe("seed によるユーザー投入", () => {
     expect(await db.select().from(user)).toHaveLength(1);
   });
 
+  it("大文字を含むメールアドレスでもサインインでき、2回実行しても増えない", async () => {
+    const 大文字混じり = "Operator@Example.com";
+
+    expect(await seedUser(大文字混じり, PASSWORD)).toMatchObject({
+      created: true,
+    });
+    expect(await seedUser(大文字混じり, PASSWORD)).toMatchObject({
+      created: false,
+    });
+    expect(await db.select().from(user)).toHaveLength(1);
+
+    const res = await post("sign-in/email", {
+      email: 大文字混じり,
+      password: PASSWORD,
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("ユーザーだけ作られた状態で中断していても、実行し直せばサインインできるようになる", async () => {
     // 1回目がユーザー作成のあとで落ちた状態を作る
     await db

--- a/server/src/auth.test.ts
+++ b/server/src/auth.test.ts
@@ -118,3 +118,44 @@ describe("サインアップ", () => {
     expect(await db.select().from(user)).toEqual([]);
   });
 });
+
+describe("Google でのサインイン", () => {
+  it("Google の同意画面のURLが返る", async () => {
+    const res = await post("sign-in/social", {
+      provider: "google",
+      callbackURL: "/",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string; redirect: boolean };
+    expect(body.redirect).toBe(true);
+    // client_id が入るのは、設定した値が実際に組み立てに使われているとき
+    const url = new URL(body.url);
+    expect(url.origin).toBe("https://accounts.google.com");
+    expect(url.searchParams.get("client_id")).toBe(
+      process.env.GOOGLE_CLIENT_ID,
+    );
+  });
+
+  // Google から戻ってきた先で Better Auth が利用者を作ろうとする一点。
+  // /callback/google も /sign-in/social に ID トークンを渡す経路も、
+  // 新しい利用者を作るときは必ずここを通る（better-auth の link-account.mjs）。
+  // 本物の Google のトークンを用意しないと経路の端から端までは通せないので、
+  // 全経路が集まるこの関数を直接叩いて、関門が効いていることを確かめる
+  it("許可していない Google アカウントでは利用者が作られない", async () => {
+    const ctx = await auth.$context;
+
+    await expect(
+      ctx.internalAdapter.createOAuthUser(
+        {
+          email: "intruder@example.com",
+          name: "侵入者",
+          emailVerified: true,
+        },
+        { providerId: "google", accountId: "google-の侵入者" },
+      ),
+    ).rejects.toThrow();
+
+    expect(await db.select().from(user)).toEqual([]);
+  });
+});

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { APIError } from "better-auth/api";
 import { nextCookies } from "better-auth/next-js";
 import { bearer } from "better-auth/plugins/bearer";
 import { db } from "./db";
@@ -14,11 +15,48 @@ if (!secret) {
   );
 }
 
+// 未設定でも Better Auth は警告を1行出すだけでプロバイダを登録する。
+// その状態で「Google でログイン」を押すと、本文の無い 500 が返って原因が分からない。
+// 起動時に落として、設定漏れをその場で分かるようにする
+const googleClientId = process.env.GOOGLE_CLIENT_ID;
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+if (!googleClientId || !googleClientSecret) {
+  throw new Error(
+    "GOOGLE_CLIENT_ID と GOOGLE_CLIENT_SECRET が設定されていない。取得の手順は docs/guides/google-oauth.md",
+  );
+}
+
 export const auth = betterAuth({
   secret,
   database: drizzleAdapter(db, { provider: "pg", schema }),
-  // 利用者は1人。ユーザーは seed スクリプトで手動投入する（設計書 §9）
+  // 利用者は1人。ユーザーは seed スクリプトで手動投入する（設計書 §9）。
+  // iOS がこの経路を使うため、管理UIを Google に変えても残す
   emailAndPassword: { enabled: true, disableSignUp: true },
+  socialProviders: {
+    google: { clientId: googleClientId, clientSecret: googleClientSecret },
+  },
+  // 許可するメールアドレスの一覧は持たない。DBに既に居る利用者としか結びつかないため、
+  // 一覧を足すと「入れてよい人」の出典が2つに増えてズレるだけになる。
+  // accountLinking も設定しない。既定が最も厳しい（同じメールアドレスで、
+  // Google 側もDB側もメール確認済みのときだけ結びつく）
+  databaseHooks: {
+    user: {
+      create: {
+        // 利用者を増やせるのは seed スクリプトだけ（設計書 §9）。seed はこのフックを
+        // 通らない経路でテーブルに直接入れるので、ここを通る作成はすべて拒む。
+        //
+        // プロバイダ側の disableSignUp では塞ぎきれない。Better Auth 1.6.26 は
+        // /callback/google では provider.options.disableSignUp を見るのに、
+        // /sign-in/social に ID トークンを直接渡す経路では provider.disableSignUp を見る。
+        // 設定から上がってくるのは前者だけなので（create-context.mjs:103）、
+        // 後者の経路は素通りして利用者が作られる。
+        // 経路ごとに塞ぐのをやめ、全経路が必ず通るここ1か所で止める
+        before: async () => {
+          throw new APIError("FORBIDDEN", { message: "signup disabled" });
+        },
+      },
+    },
+  },
   rateLimit: {
     // 既定は本番のみ有効。開発中も動かして、制限の効きを検証できる状態にする。
     // サインインは組み込みの規則で10秒に3回まで（設計書 §6）

--- a/server/src/db/seed-user.ts
+++ b/server/src/db/seed-user.ts
@@ -1,15 +1,21 @@
 import { auth } from "../auth";
+import { db } from "./index";
+import { user } from "./schema";
 
 /** メール＋パスワードのアカウントを表す Better Auth の予約値 */
 const CREDENTIAL = "credential";
 
 /**
- * 利用者を1件だけ投入する（設計書 §9）。
- * サインアップは無効なので、Better Auth のサーバー側APIを直接呼んで作る。
+ * 利用者を1件だけ投入する（設計書 §9）。サインアップは無効なので、画面からは作れない。
  *
  * サインインにはユーザーとパスワードのアカウントの両方が要る。
  * 判定をユーザーの有無ではなくアカウントの有無で行うことで、
  * ユーザーだけ作られた状態で中断しても、次の実行が足りない分を補える。
+ *
+ * ユーザーだけはテーブルへ直接入れる。`internalAdapter.createUser` は
+ * `src/auth.ts` の databaseHooks を通り、そこは「利用者を増やす作成はすべて拒む」
+ * ようにしてあるため。**このスクリプトが利用者を作れる唯一の経路** という形にして、
+ * Google の初回サインインなど他の経路が増やせないようにしている
  */
 export async function seedUser(
   email: string,
@@ -24,21 +30,28 @@ export async function seedUser(
     return { created: false, userId: found.user.id };
   }
 
-  const user =
+  const created =
     found?.user ??
-    (await ctx.internalAdapter.createUser({
-      email,
-      name: email,
-      // 運用者本人を手で入れるため、メール確認の経路は用意しない
-      emailVerified: true,
-    }));
+    (
+      await db
+        .insert(user)
+        .values({
+          id: crypto.randomUUID(),
+          email,
+          name: email,
+          // 運用者本人を手で入れるため、メール確認の経路は用意しない。
+          // Google のアカウントが結びつく条件でもある（`src/auth.ts` のコメント参照）
+          emailVerified: true,
+        })
+        .returning()
+    )[0];
 
   await ctx.internalAdapter.createAccount({
-    userId: user.id,
+    userId: created.id,
     providerId: CREDENTIAL,
-    accountId: user.id,
+    accountId: created.id,
     password: await ctx.password.hash(password),
   });
 
-  return { created: true, userId: user.id };
+  return { created: true, userId: created.id };
 }

--- a/server/src/db/seed-user.ts
+++ b/server/src/db/seed-user.ts
@@ -18,10 +18,15 @@ const CREDENTIAL = "credential";
  * Google の初回サインインなど他の経路が増やせないようにしている
  */
 export async function seedUser(
-  email: string,
+  rawEmail: string,
   password: string,
 ): Promise<{ created: boolean; userId: string }> {
   const ctx = await auth.$context;
+
+  // Better Auth はメールアドレスを小文字にして読み書きする（internal-adapter.mjs の
+  // findUserByEmail・findOAuthUser・createUser）。直接 insert する側も揃えないと、
+  // SEED_USER_EMAIL に大文字が入っていたときに、入れた行を誰も見つけられなくなる
+  const email = rawEmail.toLowerCase();
 
   const found = await ctx.internalAdapter.findUserByEmail(email, {
     includeAccounts: true,


### PR DESCRIPTION
Closes #77

管理UIに「Google でログイン」を足した。メールアドレスとパスワードの経路は iOS が使うため残す。

## 何を変えたか

| ファイル | 内容 |
|---|---|
| `server/src/auth.ts` | `socialProviders.google` を登録。`databaseHooks.user.create.before` で利用者の作成を全部拒む |
| `server/src/db/seed-user.ts` | 上のフックを通らないよう、ユーザーだけテーブルへ直接入れる。メールアドレスは小文字に揃える |
| `server/app/signin/` | 「Google でログイン」ボタン。失敗の理由を `/signin` で受けて出す |
| `docs/guides/google-oauth.md` | 新規。Google Cloud Console の手順と確認方法 |
| `docs/guides/deploy.md`・`server/.env.example`・`CLAUDE.md`・設計書 §9 | 設定の置き場所 |

## 残る判断をどう決めたか

Issue の「残る判断」4点は、討論役2体を別々に立てて主張させ、**実際に走らせて**決めた。

| 判断 | 結論 | 決め手 |
|---|---|---|
| 許可するメールアドレスの絞り方 | `ALLOWED_EMAILS` は足さない | DBに居る利用者がそのまま「入れてよい人」になる。一覧を足すと出典が2つに増えてズレるだけ |
| 既存の利用者との結びつけ | `accountLinking` は書かない | 既定が最も厳しい（両側メール確認済みのときだけ結びつく）。`trustedProviders: ["google"]` を書くと**弱くなる** |
| パスワードのフォームを消すか | 残す | Issue の受け入れ条件に無く、消すと設定漏れの日に管理UIへ入れなくなる。討論が収束しなかったので現状維持 |
| 開発中も Google を通すか | 通す | 受け入れ条件の検証（`localhost:3000` で本物の `client_id` を含むURLが返る）が、通さないと手元で実行できない |

## なぜ `disableSignUp` ではなく DB のフックなのか

**プロバイダ側の `disableSignUp: true` には、Better Auth 1.6.26 で効かない経路がある。**

- `/api/auth/callback/google` は `provider.options.disableSignUp` を見る → 効く
- `/api/auth/sign-in/social` に ID トークンを直接渡す経路は `provider.disableSignUp` を見る → **効かない**

設定から上がってくるのは前者だけ（`create-context.mjs:103` が `disableImplicitSignUp` しかコピーしない）。後者は素通りして利用者が作られる。経路ごとに塞ぐのをやめ、全経路が必ず通る `createOAuthUser` の手前1か所で止めている。

## 壊して赤くなることを確かめた

| 壊したもの | 結果 |
|---|---|
| `databaseHooks` の `throw` を消す | ❌ `intruder@example.com` が実際にDBに作られて失敗 |
| `socialProviders.google` を消す | ❌ `expected 404 to be 200` で失敗 |
| `seed-user.ts` の `toLowerCase()` を消す | ❌ 大文字混じりのアドレスのテストが失敗 |

**最初に書いた「ID トークンの経路が塞がっている」テストは、`disableIdTokenSignIn` を消しても緑のままだった**（本物でないトークンはどちらにせよ弾かれるため）。何も守っていないので捨て、DB層の関門に切り替えた。

## 品質ゲート

- `server`: `pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint` → 全パス（テスト200件）
- `ios`: `xcodebuild build test` → `** TEST SUCCEEDED **`（警告0）

## マージ前に残っていること

**配信先での確認は、本物のクライアントIDを入れてから。**

1. `server/.env.local` と Netlify に `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` を入れる（`docs/guides/google-oauth.md`）
2. Issue の「検証」を再実行して、`client_id` を含む Google のURLが返ることを確かめる
3. 実際に Google でログインできること・許可外のアカウントで入れないことを確かめる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Jv8FcxnzPyahJLNMZBoEf
