### PR TITLE
[docs] 本番DBのバージョンの実測値をバックアップのガイドに書く

### DIFF
--- a/docs/guides/backup.md
+++ b/docs/guides/backup.md
@@ -98,7 +98,20 @@ pg_dump: error: server version: 18.4; pg_dump version: 14.9 (Homebrew)
 pg_dump: error: aborting because of server version mismatch
 ```
 
-このMacの PATH の `pg_dump` は Homebrew の postgresql@14（14.9）で、**開発用DB（18）にも本番にも届かない**。そのため `server/scripts/dump.ts` は `/opt/homebrew/opt/postgresql@18/bin/pg_dump` を直接指している。
+| | バージョン | 測った日 |
+|---|---|---|
+| 開発用DB（Docker） | 18.4 | 2026-08-14 |
+| 本番（Supabase 東京） | **17.6** | 2026-08-14 |
+| 使う `pg_dump`（postgresql@18） | 18.3 | 2026-08-14 |
+
+本番のほうが `pg_dump` より古いので通る。測り方は下記。
+
+```bash
+cd server
+( set -a; . ./.env.deploy.local; set +a; /opt/homebrew/opt/postgresql@18/bin/psql "$DATABASE_URL" -Atc 'show server_version' )
+```
+
+このMacの PATH の `pg_dump` は Homebrew の postgresql@14（14.9）で、**開発用DB（18.4）にも本番（17.6）にも届かない**。そのため `server/scripts/dump.ts` は `/opt/homebrew/opt/postgresql@18/bin/pg_dump` を直接指している。
 
 ```bash
 brew install postgresql@18   # 入っていない場合


### PR DESCRIPTION
Issue #81 の「残る判断」のうち、唯一埋まっていなかった「Supabase の PostgreSQL バージョンを実測して手順に書く」への対応。PR #91 の時点では、このコマンドが手元の権限で実行できず未取得だった。

| | バージョン |
|---|---|
| 開発用DB（Docker） | 18.4 |
| 本番（Supabase 東京） | **17.6** |
| 使う `pg_dump`（postgresql@18） | 18.3 |

`pg_dump` のほうが新しいので、今の指定のまま本番のバックアップが取れる。**コードの変更は無し**（ドキュメントのみ）。測り方も一緒に書いたので、Supabase がアップグレードされたときに確かめ直せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS3txy6TbV1yXEDNP9Cqp2