### PR TITLE
[feat] iOS で持ち株を選び、端末に保存して絞り込む

### DIFF
--- a/ios/Ichikabu/APIClient.swift
+++ b/ios/Ichikabu/APIClient.swift
@@ -59,6 +59,13 @@ struct APIClient {
 		return try Self.events(from: data, response: response)
 	}
 
+	/// 登録されている銘柄を全件取る。認証は要らない（ログイン廃止 設計書 §3.2）
+	func stocks() async throws -> [Stock] {
+		let request = URLRequest(url: Self.baseURL.appending(path: "/api/stocks"))
+		let (data, response) = try await Self.session.data(for: request)
+		return try Self.stocks(from: data, response: response)
+	}
+
 	// 以下は引数だけで動く。通信をせずにテストできるように分けている
 
 	/// 応答ヘッダからトークンを取り出す
@@ -68,6 +75,12 @@ struct APIClient {
 			throw APIError.missingToken
 		}
 		return token
+	}
+
+	/// 応答を銘柄の配列に読み取る
+	static func stocks(from data: Data, response: URLResponse) throws -> [Stock] {
+		_ = try verified(response)
+		return try JSONDecoder().decode([Stock].self, from: data)
 	}
 
 	/// 応答をイベントの配列に読み取る

--- a/ios/Ichikabu/CalendarView.swift
+++ b/ios/Ichikabu/CalendarView.swift
@@ -8,9 +8,18 @@ struct CalendarView: View {
 	let onUnauthorized: () -> Void
 
 	@State private var events: [Event] = []
+	/// 絞り込みに使う銘柄。市場とテーマは持ち株のIDだけでは引けない
+	@State private var stocks: [Stock] = []
 	@State private var message: String?
 	/// 起動月を0として、何ヶ月ずれた月を見ているか
 	@State private var monthOffset = 0
+
+	/// 選んだ持ち株。端末に保存したものを起動時に読む
+	@State private var holdings: [Int] = HoldingStore().load()
+	/// 持ち株を選ぶ画面を出しているか
+	@State private var isPickingHoldings = false
+
+	private let store = HoldingStore()
 
 	/// ページの基準になる日。`@State` にすることで初期化が1回だけになり、
 	/// 親の `body` が再評価されても（`let` と違って）値が変わらない
@@ -23,12 +32,58 @@ struct CalendarView: View {
 	private static let monthRange = -12...12
 
 	var body: some View {
+		// 出すのは持ち株に対応するイベントだけ。絞り込みは端末で行う（ログイン廃止 設計書 §4）
+		let shown = EventLayout.visible(events, holdings: holdings, stocks: stocks)
+
+		NavigationStack {
+			VStack(spacing: 0) {
+				// 案内は TabView の外に置く。中に入れると前後12ヶ月の25ページに複製される
+				if holdings.isEmpty {
+					holdingsPrompt
+				}
+				grid(shown: shown)
+			}
+			.navigationBarTitleDisplayMode(.inline)
+			.toolbar {
+				// 常に見える入り口。持ち株を選んだあとも選び直せるようにする
+				ToolbarItem(placement: .topBarTrailing) {
+					Button("持ち株") { isPickingHoldings = true }
+				}
+			}
+		}
+		.sheet(isPresented: $isPickingHoldings) {
+			HoldingsView(stocks: stocks, holdings: savedHoldings)
+		}
+		.task {
+			await load()
+		}
+	}
+
+	/// 持ち株を1つも選んでいないときの案内。選ぶまで消えない
+	private var holdingsPrompt: some View {
+		Button { isPickingHoldings = true } label: {
+			HStack {
+				Text("持ち株が未選択です")
+				Spacer()
+				Text("選ぶ").fontWeight(.semibold)
+			}
+			.font(.caption)
+			.padding(.horizontal, 12)
+			.padding(.vertical, 8)
+			.frame(maxWidth: .infinity)
+			.background(Color.yellow.opacity(0.25))
+			.contentShape(Rectangle())
+		}
+		.buttonStyle(.plain)
+	}
+
+	private func grid(shown: [Event]) -> some View {
 		TabView(selection: $monthOffset) {
 			ForEach(Self.monthRange, id: \.self) { offset in
 				MonthPage(
 					monthStart: EventLayout.month(offset: offset, from: today),
 					today: today,
-					events: events,
+					events: shown,
 					onSelect: { selectedDay = $0 }
 				)
 				.tag(offset)
@@ -37,7 +92,14 @@ struct CalendarView: View {
 		.tabViewStyle(.page(indexDisplayMode: .never))
 		.overlay {
 			if let message {
-				Text(message).foregroundStyle(.secondary)
+				// `.task` は画面が出たときの1回しか走らないため、押して取り直せるようにする。
+				// これが無いと復旧はアプリの再起動だけになる
+				Button { Task { await load() } } label: {
+					VStack(spacing: 4) {
+						Text(message).foregroundStyle(.secondary)
+						Text("再試行")
+					}
+				}
 			}
 		}
 		// `.sheet(item:)` ではなく `isPresented` で出す。item だと日付が変わるたびに
@@ -50,7 +112,7 @@ struct CalendarView: View {
 					DaySheet(
 						date: selectedDay,
 						events: EventLayout.events(
-							on: EventLayout.key(for: selectedDay), from: events)
+							on: EventLayout.key(for: selectedDay), from: shown)
 					)
 				}
 			}
@@ -59,9 +121,6 @@ struct CalendarView: View {
 			// これでシートを開いたまま別の日付をタップできる（全体設計書 §10.1）
 			.presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.45)))
 		}
-		.task {
-			await load()
-		}
 	}
 
 	/// 日が選ばれていればシートを出す。閉じられたら選択も消す
@@ -69,9 +128,26 @@ struct CalendarView: View {
 		Binding(get: { selectedDay != nil }, set: { if !$0 { selectedDay = nil } })
 	}
 
+	/// 選んだ持ち株。書き込むと同時に端末へ保存する。
+	/// 保存を通らずに持ち株が変わる経路を作らないため、書き込み口はこれ1つにする
+	private var savedHoldings: Binding<[Int]> {
+		Binding(
+			get: { holdings },
+			set: {
+				holdings = $0
+				store.save($0)
+			})
+	}
+
 	private func load() async {
 		do {
-			events = try await APIClient().events(token: token)
+			// 2本を1回で受け取る。片方が失敗すると代入に届かないので、
+			// 銘柄一覧が無いまま絞ったふりのカレンダーを描くことがない
+			async let events = APIClient().events(token: token)
+			async let stocks = APIClient().stocks()
+			(self.events, self.stocks) = try await (events, stocks)
+			// 再試行で取れたら文言を消す
+			message = nil
 		} catch APIError.unauthorized {
 			onUnauthorized()
 		} catch {

--- a/ios/Ichikabu/CalendarView.swift
+++ b/ios/Ichikabu/CalendarView.swift
@@ -51,9 +51,6 @@ struct CalendarView: View {
 				}
 			}
 		}
-		.sheet(isPresented: $isPickingHoldings) {
-			HoldingsView(stocks: stocks, holdings: savedHoldings)
-		}
 		.task {
 			await load()
 		}
@@ -103,12 +100,19 @@ struct CalendarView: View {
 			}
 		}
 		// `.sheet(item:)` ではなく `isPresented` で出す。item だと日付が変わるたびに
-		// シートを出し直すため、0.45 で開いていたシートが `.large` に広がってしまう（設計書 §3）
+		// シートを出し直すため、0.45 で開いていたシートが `.large` に広がってしまう（設計書 §3）。
+		//
+		// 日付と持ち株でシートを2枚に分けない。シートは1枚しか出せないのに、
+		// 0.45 の間は裏を操作できる（下の `presentationBackgroundInteraction`）ため、
+		// 日付のシートを開いたままツールバーの「持ち株」を押せてしまう。
+		// 1枚の中身を入れ替える形にすれば、2枚目を出す要求そのものが起きない
 		.sheet(isPresented: sheetIsShown) {
 			// 高さの指定は if の外側に置く。内側だと、閉じるときに selectedDay が
 			// nil になった時点で消えていくシートから指定が外れる
 			Group {
-				if let selectedDay {
+				if isPickingHoldings {
+					HoldingsView(stocks: stocks, holdings: savedHoldings)
+				} else if let selectedDay {
 					DaySheet(
 						date: selectedDay,
 						events: EventLayout.events(
@@ -116,16 +120,24 @@ struct CalendarView: View {
 					)
 				}
 			}
-			.presentationDetents([.fraction(0.45), .large])
+			// 持ち株の一覧は 0.45 では狭いので、そのときだけ大きいままにする
+			.presentationDetents(isPickingHoldings ? [.large] : [.fraction(0.45), .large])
 			// 0.45 まで下げている間は裏を操作できる。
 			// これでシートを開いたまま別の日付をタップできる（全体設計書 §10.1）
 			.presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.45)))
 		}
 	}
 
-	/// 日が選ばれていればシートを出す。閉じられたら選択も消す
+	/// 日が選ばれているか、持ち株を選んでいる間はシートを出す。閉じられたら両方消す
 	private var sheetIsShown: Binding<Bool> {
-		Binding(get: { selectedDay != nil }, set: { if !$0 { selectedDay = nil } })
+		Binding(
+			get: { isPickingHoldings || selectedDay != nil },
+			set: {
+				if !$0 {
+					isPickingHoldings = false
+					selectedDay = nil
+				}
+			})
 	}
 
 	/// 選んだ持ち株。書き込むと同時に端末へ保存する。
@@ -151,7 +163,9 @@ struct CalendarView: View {
 		} catch APIError.unauthorized {
 			onUnauthorized()
 		} catch {
-			message = "イベントを取得できませんでした"
+			// 銘柄一覧が落ちた場合もここに来る。片方だけ落ちても画面には何も出ないため、
+			// 文言はイベントに限定しない
+			message = "イベントと銘柄を取得できませんでした"
 		}
 	}
 }

--- a/ios/Ichikabu/CalendarView.swift
+++ b/ios/Ichikabu/CalendarView.swift
@@ -28,6 +28,11 @@ struct CalendarView: View {
 	/// タップされた日。nil の間はシートを出さない
 	@State private var selectedDay: Date?
 
+	/// シートの高さ。日付は 0.45、持ち株の一覧は狭いので `.large` で開く。
+	/// 高さの候補（`presentationDetents` に渡す集合）は変えずに、選ぶほうだけを変える。
+	/// 集合を出し分けると、閉じている最中に候補が入れ替わることになる
+	@State private var sheetHeight: PresentationDetent = .fraction(0.45)
+
 	/// 起動月の前後12ヶ月（設計書 §2 判断5）
 	private static let monthRange = -12...12
 
@@ -47,7 +52,7 @@ struct CalendarView: View {
 			.toolbar {
 				// 常に見える入り口。持ち株を選んだあとも選び直せるようにする
 				ToolbarItem(placement: .topBarTrailing) {
-					Button("持ち株") { isPickingHoldings = true }
+					Button("持ち株") { showHoldings() }
 				}
 			}
 		}
@@ -56,9 +61,23 @@ struct CalendarView: View {
 		}
 	}
 
+	/// 持ち株を選ぶ画面を出す
+	private func showHoldings() {
+		sheetHeight = .large
+		isPickingHoldings = true
+	}
+
+	/// その日のイベントのシートを出す。
+	/// 高さを 0.45 に戻すのは、持ち株の一覧で `.large` にしたまま日付を開くと
+	/// カレンダーが隠れ、続けて別の日付をタップできなくなるため（設計書 §3）
+	private func showDay(_ day: Date) {
+		sheetHeight = .fraction(0.45)
+		selectedDay = day
+	}
+
 	/// 持ち株を1つも選んでいないときの案内。選ぶまで消えない
 	private var holdingsPrompt: some View {
-		Button { isPickingHoldings = true } label: {
+		Button { showHoldings() } label: {
 			HStack {
 				Text("持ち株が未選択です")
 				Spacer()
@@ -81,7 +100,7 @@ struct CalendarView: View {
 					monthStart: EventLayout.month(offset: offset, from: today),
 					today: today,
 					events: shown,
-					onSelect: { selectedDay = $0 }
+					onSelect: { showDay($0) }
 				)
 				.tag(offset)
 			}
@@ -120,8 +139,7 @@ struct CalendarView: View {
 					)
 				}
 			}
-			// 持ち株の一覧は 0.45 では狭いので、そのときだけ大きいままにする
-			.presentationDetents(isPickingHoldings ? [.large] : [.fraction(0.45), .large])
+			.presentationDetents([.fraction(0.45), .large], selection: $sheetHeight)
 			// 0.45 まで下げている間は裏を操作できる。
 			// これでシートを開いたまま別の日付をタップできる（全体設計書 §10.1）
 			.presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.45)))

--- a/ios/Ichikabu/EventLayout.swift
+++ b/ios/Ichikabu/EventLayout.swift
@@ -83,6 +83,30 @@ enum EventLayout {
 		return (inMonth.count, inMonth.filter { $0.importance == 3 }.count)
 	}
 
+	/// 持ち株に出すイベントだけに絞る。判定はサーバーと同じ4条件
+	/// （`GLOBAL` は全員・持ち株の市場・持ち株そのもの・持ち株が属するテーマ）。
+	///
+	/// `stocks` が要るのは、市場とテーマが持ち株のIDだけでは引けないため。
+	/// 銘柄一覧が取れていなければ市場イベントもテーマイベントも判定できないので、
+	/// `GLOBAL` と持ち株のイベントだけが残る
+	static func visible(_ events: [Event], holdings: [Int], stocks: [Stock]) -> [Event] {
+		let held = stocks.filter { holdings.contains($0.id) }
+		// `Stock.market`（JP・US）と `EventMarket`（JP・US・GLOBAL）は値の集合が違うので
+		// 別の型になる。文字列に直して比べるのはここだけ（ログイン廃止 設計書 §3.1）
+		let markets = Set(held.map(\.market.rawValue))
+		let themeIds = Set(held.flatMap(\.themeIds))
+		return events.filter { event in
+			switch event.target {
+			case .market(let target):
+				target.market == .GLOBAL || markets.contains(target.market.rawValue)
+			case .theme(let target):
+				themeIds.contains(target.themeId)
+			case .stock(let target):
+				holdings.contains(target.stockId)
+			}
+		}
+	}
+
 	/// シートの見出し（`8月4日（火）`）
 	static func dayTitle(for date: Date) -> String {
 		let components = calendar.dateComponents([.month, .day, .weekday], from: date)

--- a/ios/Ichikabu/EventLayout.swift
+++ b/ios/Ichikabu/EventLayout.swift
@@ -2,7 +2,7 @@ import Foundation
 import IchikabuAPI
 import SwiftUI
 
-/// 月グリッドの日付計算とイベントの割り当て。
+/// 月グリッドの日付計算と、イベントの割り当て・絞り込み。
 /// 画面から切り離してテストできるように、状態を持たない関数だけを置く
 enum EventLayout {
 	/// 日付の計算はすべてJST・グレゴリオ暦・日曜始まりで行う。

--- a/ios/Ichikabu/HoldingStore.swift
+++ b/ios/Ichikabu/HoldingStore.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// 選んだ持ち株（銘柄ID）を端末に読み書きする（ログイン廃止 設計書 §4.1）。
+///
+/// 置くのは銘柄IDの配列だけなので、数十バイトで済む。スキーマもマイグレーションも要らない。
+/// Apple Developer Program に加入したら `NSUbiquitousKeyValueStore` に差し替えて
+/// 機種変更で引き継げるようにする。**差し替えるのはこの型の中だけ**（同 §4.2）。
+struct HoldingStore {
+	private static let key = "holdings"
+
+	/// 入れ物。テストは `UserDefaults(suiteName:)` を渡す。
+	/// シミュレータの標準の入れ物はアプリを消すまで残り、前の実行の値を拾うため
+	private let defaults: UserDefaults
+
+	init(defaults: UserDefaults = .standard) {
+		self.defaults = defaults
+	}
+
+	func load() -> [Int] {
+		// 選んでいなければキー自体が無い。別の型が入っていた場合も選び直しで直せるので空にする
+		defaults.array(forKey: Self.key) as? [Int] ?? []
+	}
+
+	func save(_ stockIds: [Int]) {
+		defaults.set(stockIds, forKey: Self.key)
+	}
+}

--- a/ios/Ichikabu/HoldingsView.swift
+++ b/ios/Ichikabu/HoldingsView.swift
@@ -15,6 +15,8 @@ struct HoldingsView: View {
 				// （Issue #87 の検証時の罠）、選べたことはこの行のチェックで示す
 				Button { toggle(stock.id) } label: { row(for: stock) }
 					.buttonStyle(.plain)
+					// チェックの印は目で見る人にしか伝わらないため、選択の状態を VoiceOver にも渡す
+					.accessibilityAddTraits(holdings.contains(stock.id) ? .isSelected : [])
 			}
 			.listStyle(.plain)
 			.overlay {
@@ -42,8 +44,6 @@ struct HoldingsView: View {
 				Image(systemName: "checkmark").foregroundStyle(Color.accentColor)
 			}
 		}
-		// チェックの印は目で見る人にしか伝わらないため、選択の状態を VoiceOver にも渡す
-		.accessibilityAddTraits(holdings.contains(stock.id) ? .isSelected : [])
 		// これが無いと、行の余白（銘柄名の右側）を押しても反応しない
 		.contentShape(Rectangle())
 	}

--- a/ios/Ichikabu/HoldingsView.swift
+++ b/ios/Ichikabu/HoldingsView.swift
@@ -1,0 +1,54 @@
+import IchikabuAPI
+import SwiftUI
+
+/// 持ち株を選ぶ画面。登録されている銘柄を全件並べ、タップで選ぶ・外す。
+/// 検索は付けない。銘柄は手入力で増える範囲にとどまるため（ログイン廃止 設計書 §6）
+struct HoldingsView: View {
+	let stocks: [Stock]
+	/// 選んだ銘柄ID。書き込みは呼び出し側で端末に保存される
+	@Binding var holdings: [Int]
+
+	var body: some View {
+		NavigationStack {
+			List(stocks, id: \.id) { stock in
+				// 選んだ銘柄のイベントが段階2ではまだ出ないことがあるため
+				// （Issue #87 の検証時の罠）、選べたことはこの行のチェックで示す
+				Button { toggle(stock.id) } label: { row(for: stock) }
+					.buttonStyle(.plain)
+			}
+			.listStyle(.plain)
+			.overlay {
+				if stocks.isEmpty {
+					Text("銘柄がありません").foregroundStyle(.secondary)
+				}
+			}
+			.navigationTitle("持ち株")
+			.navigationBarTitleDisplayMode(.inline)
+		}
+	}
+
+	private func row(for stock: Stock) -> some View {
+		HStack {
+			VStack(alignment: .leading, spacing: 2) {
+				Text(stock.name)
+				Text("\(stock.market.rawValue) \(stock.ticker)")
+					.font(.caption)
+					.foregroundStyle(.secondary)
+			}
+			Spacer()
+			if holdings.contains(stock.id) {
+				Image(systemName: "checkmark").foregroundStyle(Color.accentColor)
+			}
+		}
+		// これが無いと、行の余白（銘柄名の右側）を押しても反応しない
+		.contentShape(Rectangle())
+	}
+
+	private func toggle(_ stockId: Int) {
+		if let index = holdings.firstIndex(of: stockId) {
+			holdings.remove(at: index)
+		} else {
+			holdings.append(stockId)
+		}
+	}
+}

--- a/ios/Ichikabu/HoldingsView.swift
+++ b/ios/Ichikabu/HoldingsView.swift
@@ -19,7 +19,9 @@ struct HoldingsView: View {
 			.listStyle(.plain)
 			.overlay {
 				if stocks.isEmpty {
-					Text("銘柄がありません").foregroundStyle(.secondary)
+					// 空になるのは「1件も登録が無い」ときと「取得に失敗した」ときの両方。
+					// 前者だと言い切らない文言にする
+					Text("銘柄を取得できていません").foregroundStyle(.secondary)
 				}
 			}
 			.navigationTitle("持ち株")
@@ -40,6 +42,8 @@ struct HoldingsView: View {
 				Image(systemName: "checkmark").foregroundStyle(Color.accentColor)
 			}
 		}
+		// チェックの印は目で見る人にしか伝わらないため、選択の状態を VoiceOver にも渡す
+		.accessibilityAddTraits(holdings.contains(stock.id) ? .isSelected : [])
 		// これが無いと、行の余白（銘柄名の右側）を押しても反応しない
 		.contentShape(Rectangle())
 	}

--- a/ios/IchikabuAPI/Sources/IchikabuAPI/Contract.swift
+++ b/ios/IchikabuAPI/Sources/IchikabuAPI/Contract.swift
@@ -10,3 +10,6 @@ public typealias Health = Components.Schemas.Health
 
 /// `GET /api/events` が返すイベント
 public typealias Event = Components.Schemas.Event
+
+/// `GET /api/stocks` が返す銘柄
+public typealias Stock = Components.Schemas.Stock

--- a/ios/IchikabuTests/APIClientTests.swift
+++ b/ios/IchikabuTests/APIClientTests.swift
@@ -63,6 +63,22 @@ struct APIClientTests {
 		#expect(events[0].source?.url == "https://www.stat.go.jp/data/cpi/")
 	}
 
+	@Test("サーバーが返す形の JSON を銘柄に読み取れる")
+	func decodeStocks() throws {
+		let json = Data(
+			"""
+			[{"id":1,"market":"JP","ticker":"7203","name":"トヨタ自動車","themeIds":[10]},\
+			{"id":2,"market":"US","ticker":"NVDA","name":"NVIDIA","themeIds":[]}]
+			""".utf8)
+		let stocks = try APIClient.stocks(from: json, response: response(status: 200))
+		#expect(stocks.count == 2)
+		#expect(stocks[0].market == .JP)
+		#expect(stocks[0].ticker == "7203")
+		// 所属テーマは端末側のテーマイベントの判定に使う（ログイン廃止 設計書 §3.2）
+		#expect(stocks[0].themeIds == [10])
+		#expect(stocks[1].themeIds.isEmpty)
+	}
+
 	@Test("サインインの応答ヘッダからトークンを取り出す")
 	func extractToken() throws {
 		let token = try APIClient.token(

--- a/ios/IchikabuTests/HoldingFilterTests.swift
+++ b/ios/IchikabuTests/HoldingFilterTests.swift
@@ -1,0 +1,106 @@
+import IchikabuAPI
+import Testing
+
+@testable import Ichikabu
+
+@Suite("持ち株による絞り込み")
+struct HoldingFilterTests {
+	/// JP の銘柄。テーマ10に属する
+	private let toyota = Stock(
+		id: 1, market: .JP, ticker: "7203", name: "トヨタ自動車", themeIds: [10])
+	/// US の銘柄。どのテーマにも属さない
+	private let nvidia = Stock(
+		id: 2, market: .US, ticker: "NVDA", name: "NVIDIA", themeIds: [])
+
+	/// テスト用のイベントを1件作る。対象以外は判定に影響しないので固定値でよい。
+	/// `kind` は対象から導く。契約は食い違う組み合わせも表せるため、テストでも必ず揃える
+	private func event(id: String, target: Components.Schemas.EventTarget) -> Event {
+		Event(
+			id: id,
+			kind: {
+				switch target {
+				case .market: .market
+				case .theme: .theme
+				case .stock: .stock
+				}
+			}(),
+			title: "テスト",
+			shortLabel: "テスト",
+			startDate: "2026-09-16",
+			endDate: nil,
+			time: nil,
+			importance: 1,
+			note: nil,
+			source: nil,
+			target: target
+		)
+	}
+
+	private func stockEvent(id: String, stockId: Int) -> Event {
+		event(id: id, target: .stock(.init(_type: .stock, stockId: stockId)))
+	}
+
+	private func themeEvent(id: String, themeId: Int) -> Event {
+		event(id: id, target: .theme(.init(_type: .theme, themeId: themeId)))
+	}
+
+	private func marketEvent(id: String, market: Components.Schemas.EventMarket) -> Event {
+		event(id: id, target: .market(.init(_type: .market, market: market)))
+	}
+
+	@Test("選んだ銘柄のイベントだけが出る")
+	func selectedStockOnly() {
+		let events = [stockEvent(id: "held", stockId: 1), stockEvent(id: "other", stockId: 2)]
+
+		let visible = EventLayout.visible(events, holdings: [1], stocks: [toyota, nvidia])
+
+		#expect(visible.map(\.id) == ["held"])
+	}
+
+	@Test("1つも選んでいなければ GLOBAL の市場イベントだけが出る")
+	func nothingSelected() {
+		let events = [
+			marketEvent(id: "global", market: .GLOBAL),
+			marketEvent(id: "jp", market: .JP),
+			stockEvent(id: "stock", stockId: 1),
+			themeEvent(id: "theme", themeId: 10),
+		]
+
+		let visible = EventLayout.visible(events, holdings: [], stocks: [toyota, nvidia])
+
+		#expect(visible.map(\.id) == ["global"])
+	}
+
+	@Test("持ち株の市場の市場イベントが出る。別の市場のものは出ない")
+	func marketOfHeldStock() {
+		let events = [marketEvent(id: "jp", market: .JP), marketEvent(id: "us", market: .US)]
+
+		let visible = EventLayout.visible(events, holdings: [1], stocks: [toyota, nvidia])
+
+		#expect(visible.map(\.id) == ["jp"])
+	}
+
+	@Test("持ち株が属するテーマのイベントが出る。属さないテーマのものは出ない")
+	func themeOfHeldStock() {
+		let events = [themeEvent(id: "belongs", themeId: 10), themeEvent(id: "other", themeId: 11)]
+
+		let visible = EventLayout.visible(events, holdings: [1], stocks: [toyota, nvidia])
+
+		#expect(visible.map(\.id) == ["belongs"])
+	}
+
+	@Test("銘柄一覧が取れていなければ、市場もテーマも判定できないので出ない")
+	func withoutStocks() {
+		let events = [
+			marketEvent(id: "global", market: .GLOBAL),
+			marketEvent(id: "jp", market: .JP),
+			themeEvent(id: "theme", themeId: 10),
+		]
+
+		// 取得に失敗するとイベント自体も空になるが、絞り込みだけを見ると
+		// 持ち株の市場とテーマは引けない。GLOBAL は誰にでも出る
+		let visible = EventLayout.visible(events, holdings: [1], stocks: [])
+
+		#expect(visible.map(\.id) == ["global"])
+	}
+}

--- a/ios/IchikabuTests/HoldingStoreTests.swift
+++ b/ios/IchikabuTests/HoldingStoreTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import Ichikabu
+
+@Suite("持ち株の保管")
+struct HoldingStoreTests {
+	/// テスト用の入れ物を作る。`UserDefaults.standard` は使わない。
+	/// シミュレータの標準の入れ物はアプリを消すまで残り、前の実行の値を拾うため
+	private func defaults(_ suiteName: String) -> UserDefaults {
+		guard let defaults = UserDefaults(suiteName: suiteName) else {
+			fatalError("テスト用の UserDefaults を作れない: \(suiteName)")
+		}
+		defaults.removePersistentDomain(forName: suiteName)
+		return defaults
+	}
+
+	@Test("選んだ持ち株は、アプリを開き直しても残っている")
+	func persists() {
+		let suiteName = "holding-store-persists"
+		let defaults = defaults(suiteName)
+		defer { defaults.removePersistentDomain(forName: suiteName) }
+
+		HoldingStore(defaults: defaults).save([7203, 6758])
+
+		// 開き直した状態は、値を持たない新しい HoldingStore から読むことで作る
+		#expect(HoldingStore(defaults: defaults).load() == [7203, 6758])
+	}
+
+	@Test("選び直すと前の内容は残らない")
+	func replaces() {
+		let suiteName = "holding-store-replaces"
+		let defaults = defaults(suiteName)
+		defer { defaults.removePersistentDomain(forName: suiteName) }
+
+		let store = HoldingStore(defaults: defaults)
+		store.save([7203])
+		store.save([6758])
+
+		#expect(store.load() == [6758])
+	}
+
+	@Test("一度も選んでいなければ空")
+	func empty() {
+		let suiteName = "holding-store-empty"
+		let defaults = defaults(suiteName)
+		defer { defaults.removePersistentDomain(forName: suiteName) }
+
+		#expect(HoldingStore(defaults: defaults).load().isEmpty)
+	}
+}

--- a/ios/IchikabuTests/HoldingStoreTests.swift
+++ b/ios/IchikabuTests/HoldingStoreTests.swift
@@ -7,18 +7,16 @@ import Testing
 struct HoldingStoreTests {
 	/// テスト用の入れ物を作る。`UserDefaults.standard` は使わない。
 	/// シミュレータの標準の入れ物はアプリを消すまで残り、前の実行の値を拾うため
-	private func defaults(_ suiteName: String) -> UserDefaults {
-		guard let defaults = UserDefaults(suiteName: suiteName) else {
-			fatalError("テスト用の UserDefaults を作れない: \(suiteName)")
-		}
+	private func defaults(_ suiteName: String) throws -> UserDefaults {
+		let defaults = try #require(UserDefaults(suiteName: suiteName))
 		defaults.removePersistentDomain(forName: suiteName)
 		return defaults
 	}
 
 	@Test("選んだ持ち株は、アプリを開き直しても残っている")
-	func persists() {
+	func persists() throws {
 		let suiteName = "holding-store-persists"
-		let defaults = defaults(suiteName)
+		let defaults = try defaults(suiteName)
 		defer { defaults.removePersistentDomain(forName: suiteName) }
 
 		HoldingStore(defaults: defaults).save([7203, 6758])
@@ -28,9 +26,9 @@ struct HoldingStoreTests {
 	}
 
 	@Test("選び直すと前の内容は残らない")
-	func replaces() {
+	func replaces() throws {
 		let suiteName = "holding-store-replaces"
-		let defaults = defaults(suiteName)
+		let defaults = try defaults(suiteName)
 		defer { defaults.removePersistentDomain(forName: suiteName) }
 
 		let store = HoldingStore(defaults: defaults)
@@ -41,9 +39,9 @@ struct HoldingStoreTests {
 	}
 
 	@Test("一度も選んでいなければ空")
-	func empty() {
+	func empty() throws {
 		let suiteName = "holding-store-empty"
-		let defaults = defaults(suiteName)
+		let defaults = try defaults(suiteName)
 		defer { defaults.removePersistentDomain(forName: suiteName) }
 
 		#expect(HoldingStore(defaults: defaults).load().isEmpty)


### PR DESCRIPTION
Closes #87

iOS で持ち株を選び、端末（`UserDefaults`）に保存して、イベントの絞り込みを端末で行う。ログイン廃止の**段階2**（設計書: `docs/records/specs/2026-08-14-86-no-login-design.md` §4）。サーバー側の保有による絞り込みは残っているので、端末の絞りはさらに狭めるだけになる。

## 中身

| ファイル | 中身 |
|---|---|
| `ios/Ichikabu/HoldingStore.swift`（新） | 選んだ銘柄IDの読み書き。iCloud（`NSUbiquitousKeyValueStore`）へ差し替えるときはこの型の中だけを変える |
| `ios/Ichikabu/HoldingsView.swift`（新） | 銘柄一覧から選ぶ画面。行のチェックが「保存された」ことの証拠になる |
| `ios/Ichikabu/EventLayout.swift` | `visible(_:holdings:stocks:)`。サーバーと同じ4条件（GLOBAL・持ち株の市場・持ち株・持ち株のテーマ）で絞る純関数 |
| `ios/Ichikabu/APIClient.swift` | `GET /api/stocks` の取得と読み取り |
| `ios/Ichikabu/CalendarView.swift` | 配線・未選択の案内・再試行 |

## 決めたこと（討論して収束させた）

| 判断 | 結論 | 決め手 |
|---|---|---|
| 選ぶ画面 | ツールバーの常設ボタン →シートで全件一覧。検索は付けない | 月送りが `TabView(.page)` を使い切っており、下タブは入れ子になる。銘柄は今3件で、検索が要る日に1行足せる |
| 取得に失敗したとき | イベントと銘柄を1回で受け取り、片方が失敗したらどちらも代入しない | 銘柄一覧が無いと市場もテーマも判定できない。絞れていないカレンダーを正常時と同じ顔で描かないため |
| 未選択の案内 | `TabView` の外に1本のバー。持ち株が空の間だけ出す | `MonthPage` に置くと前後12ヶ月の25ページに複製される |
| 再試行 | この Issue の範囲に入れた | 失敗の窓口を1本から2本に増やすのはこの変更自身。`.task` は画面が出たときの1回しか走らないため、今の復旧手段はアプリの再起動だけだった |

棄却した案: `.searchable`（要る日に1行）・起動時に選ぶ画面を出す（「選ばずに閉じた」を覚える保存項目が増える）・`.refreshable`（横スワイプと同居し入り口が2つになる）。

## 直した根拠（壊して赤くなることで示す）

実装をわざと壊し、対応するテストだけが赤くなることを確認した。

| 壊した箇所 | 赤くなったテスト |
|---|---|
| `GLOBAL` の条件を落とす | 「1つも選んでいなければ GLOBAL の市場イベントだけが出る」「銘柄一覧が取れていなければ…」 |
| 市場の一致判定を無条件にする | 「持ち株の市場の市場イベントが出る。別の市場のものは出ない」ほか2件 |
| テーマの判定を無条件にする | 「持ち株が属するテーマのイベントが出る。属さないテーマのものは出ない」ほか2件 |
| 銘柄の判定を無条件にする | 「選んだ銘柄のイベントだけが出る」ほか1件 |
| 端末への保存を止める | 「選んだ持ち株は、アプリを開き直しても残っている」「選び直すと前の内容は残らない」 |

## シミュレータでの確認

テストが届かない画面の振る舞いは、開発DBに確認用のデータを入れて実際に見た（確認後、入れたデータは消してある）。

- 未選択の起動: 案内バーとツールバーの「持ち株」が出て、GLOBAL のイベントだけが並ぶ。他銘柄の決算・US 市場イベント・テーマイベントは出ない
- 持ち株をトヨタ（`stockId` 1）だけにした状態: 7203の決算・GLOBAL・JP 市場イベントが出て、NVDA の決算・テーマイベント・US 市場イベントは出ない。案内バーも消える
- 日付シートを開いたまま「持ち株」を押した状態: 持ち株の一覧が出る（取りこぼしなし）
- 日付シートは 0.45 の高さで開く（既存の振る舞いのまま）

## 品質ゲート

- server: `pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint` → 全パス（232件）
- ios: `xcodebuild build test -scheme Ichikabu -destination 'platform=iOS Simulator,name=iPhone 17' -skipPackagePluginValidation` → `** TEST SUCCEEDED **`（33件。24件から9件増）

## 直さずに残した指摘（Minor）

- **テスト用のイベント生成が2ファイルで重複している**: `EventLayoutTests` と `HoldingFilterTests` は見るものが違い（日付の割り当て／絞り込み）、まとめると片方のテストを読むのに別ファイルを開くことになる。契約が変わったときに2箇所直す代償のほうを取った
- **選ぶ画面に閉じるボタンが無い**: 下スワイプで閉じられる。ボタンを足すと、選び終わりが「決定」に見えて、実際には1タップごとに保存されていることと食い違う

## 段階3（#88）でやること

認証と、サーバー側の保有による絞り込みを消す。端末の絞りだけが残る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCL1NwVJm4PMTjZghmDLz8
