### PR TITLE
[chore] AUDIT_RESOURCES から holding を消す

### DIFF
--- a/docs/records/specs/2026-08-14-86-no-login-design.md
+++ b/docs/records/specs/2026-08-14-86-no-login-design.md
@@ -129,6 +129,8 @@ App Store Review Guidelines 5.1.1(ii) も同じ方向を指している。
 
 **`AUDIT_RESOURCES` の `"holding"` だけは残した。** 監査ログは過去の事実の記録で、テーブルを消す前に書かれた行が `resource_type='holding'` を持ちうる。`resource_type` にDBの CHECK 制約は無いので既存行はそのまま残り、値を落とすと実際に在る文字列を型が「ありえない」と言い切ることになる。**本番の `audit_log` で `select count(*) from audit_log where resource_type = 'holding'` が0件と確認できたら消してよい。**
 
+> **この判断はもう当たらない（Issue #98）。** 本番に `audit_log` テーブルがまだ無い（監査ログを入れた `0004_careful_calypso.sql` が未適用）と実測で確かめた。次のデプロイで `0004` と `DROP TABLE holding` の `0005_thankful_jimmy_woo.sql` が同じ `pnpm db:migrate` で連続して当たるため、`resource_type='holding'` の行は過去にも将来にも生まれない。値は消し、実在するテーブル名だけが並ぶことを `server/src/db/schema.test.ts` がDBに問い合わせて見張るようにした。
+
 ### 5.2 `server/src/rights.ts` は変えない
 
 `rightsDates(year, fiscalMonth)` は年と決算月だけを受け取る純関数で、認証にも保有にも依存していない。変わるのは `route.ts` の問い合わせ1本だけ。

--- a/docs/records/specs/2026-08-14-86-no-login-design.md
+++ b/docs/records/specs/2026-08-14-86-no-login-design.md
@@ -127,7 +127,7 @@ App Store Review Guidelines 5.1.1(ii) も同じ方向を指している。
 
 **メール＋パスワードは残す。** 管理UIの `app/signin/signin-form.tsx` が Google の設定が壊れた日の入り口として使っており、`seedUser` とテストのサインインもこの経路を通る。
 
-**`AUDIT_RESOURCES` の `"holding"` だけは残した。** 監査ログは過去の事実の記録で、テーブルを消す前に書かれた行が `resource_type='holding'` を持ちうる。`resource_type` にDBの CHECK 制約は無いので既存行はそのまま残り、値を落とすと実際に在る文字列を型が「ありえない」と言い切ることになる。**本番の `audit_log` で `select count(*) from audit_log where resource_type = 'holding'` が0件と確認できたら消してよい。**
+**`AUDIT_RESOURCES` の `"holding"` だけは残した。** 監査ログは過去の事実の記録で、テーブルを消す前に書かれた行が `resource_type='holding'` を持ちうる。`resource_type` にDBの CHECK 制約は無いので既存行はそのまま残り、値を落とすと実際に在る文字列を型が「ありえない」と言い切ることになる。**本番の `audit_log` で `select count(*) from audit_log where resource_type = 'holding'` が0件と確認できたら消してよい。**（→ この確認は下の注記のとおり済んでおり、値はもう消してある）
 
 > **この判断はもう当たらない（Issue #98）。** 本番に `audit_log` テーブルがまだ無い（監査ログを入れた `0004_careful_calypso.sql` が未適用）と実測で確かめた。次のデプロイで `0004` と `DROP TABLE holding` の `0005_thankful_jimmy_woo.sql` が同じ `pnpm db:migrate` で連続して当たるため、`resource_type='holding'` の行は過去にも将来にも生まれない。値は消し、実在するテーブル名だけが並ぶことを `server/src/db/schema.test.ts` がDBに問い合わせて見張るようにした。
 

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -2,7 +2,7 @@ import { eq, sql } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { expectViolation, resetDatabase } from "../../test/helpers";
 import { db } from ".";
-import { event, stock, theme, themeStock } from "./schema";
+import { AUDIT_RESOURCES, event, stock, theme, themeStock } from "./schema";
 
 beforeEach(resetDatabase);
 
@@ -275,6 +275,20 @@ describe("theme の一意性", () => {
       db.insert(theme).values({ name: "ドローン" }),
     );
     expect(violated).toBe("theme_name_unique");
+  });
+});
+
+describe("AUDIT_RESOURCES", () => {
+  // 値は audit_log.resource_type の型そのもので、書き込みだけでなく読み出しの型も
+  // これで決まる。実在しないテーブル名が混ざっていても TypeScript は気づけないため、
+  // DBに問い合わせて確かめる（Issue #98）
+  it("並んでいる値はすべてDBに実在するテーブル名である", async () => {
+    const { rows } = await db.execute<{ table_name: string }>(sql`
+      SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public'
+    `);
+    const tables = new Set(rows.map((row) => row.table_name));
+    expect(AUDIT_RESOURCES.filter((name) => !tables.has(name))).toEqual([]);
   });
 });
 

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -283,11 +283,10 @@ describe("AUDIT_RESOURCES", () => {
   // これで決まる。実在しないテーブル名が混ざっていても TypeScript は気づけないため、
   // DBに問い合わせて確かめる（Issue #98）
   it("並んでいる値はすべてDBに実在するテーブル名である", async () => {
-    const { rows } = await db.execute<{ table_name: string }>(sql`
-      SELECT table_name FROM information_schema.tables
-       WHERE table_schema = 'public'
+    const { rows } = await db.execute<{ tablename: string }>(sql`
+      SELECT tablename FROM pg_tables WHERE schemaname = 'public'
     `);
-    const tables = new Set(rows.map((row) => row.table_name));
+    const tables = new Set(rows.map((row) => row.tablename));
     expect(AUDIT_RESOURCES.filter((name) => !tables.has(name))).toEqual([]);
   });
 });

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -32,18 +32,15 @@ export const EVENT_MARKETS = ["JP", "US", "GLOBAL"] as const;
  */
 export const AUDIT_ACTIONS = ["create", "update", "delete"] as const;
 /**
- * 記録の対象。値はDBのテーブル名そのもの。
- *
- * `holding` はテーブルごと消えたが（ログイン廃止 設計書 §5.1）、値は残す。
- * この表は過去の事実の記録で、消す前に書かれた行が `resource_type='holding'` を
- * 持っている。値を落とすと、実際にDBに在る文字列を型が「ありえない」と言い切る。
- * 本番の `audit_log` にその行が1件も無いと確認できたら消してよい（→ Issue #98）
+ * 記録の対象。値はDBのテーブル名そのもので、実在するテーブルだけを並べる。
+ * この列は書き込みだけでなく読み出しの型も決めるため、DBに在る文字列を
+ * 落とすと、その行を読んだときに型が嘘をつく。
+ * 実在するかは `src/db/schema.test.ts` がDBに問い合わせて確かめている
  */
 export const AUDIT_RESOURCES = [
   "stock",
   "theme",
   "event",
-  "holding",
   "theme_stock",
 ] as const;
 


### PR DESCRIPTION
Closes #98

## 決め手

**本番に `audit_log` テーブル自体がまだ無い。** 本番DBへ読み取り1回を実行した結果:

```
ERR relation "audit_log" does not exist
```

監査ログを入れた `0004_careful_calypso.sql` が未適用（＝この機能をまだデプロイしていない）ため、`resource_type='holding'` の行は0件で確定した。

将来も生まれない。次のデプロイで `0004`（`audit_log` 作成）と `0005_thankful_jimmy_woo.sql`（`DROP TABLE holding`）が同じ `pnpm db:migrate` で連続して当たるため、`holding` テーブルが在って `audit_log` も在る瞬間が存在しない。Issue #98 の「検証時の罠」に書かれていたケースそのもの。

## 変更

| ファイル | 内容 |
|---|---|
| `server/src/db/schema.ts` | `AUDIT_RESOURCES` から `"holding"` を消し、残す理由を書いていたコメントを差し替え |
| `server/src/db/schema.test.ts` | 値がすべてDBに実在するテーブル名であることを、`pg_tables` に問い合わせて確かめるテストを追加 |
| `docs/records/specs/2026-08-14-86-no-login-design.md` | §5.1 の「消してよい条件」に結末を書き足す |

## 直した根拠（赤で示す）

追加したテストは、消す前の状態で `"holding"` を名指しして落ちる。

```
- []
+ [ "holding" ]
 ❯ src/db/schema.test.ts:290
```

レビュー指摘で `information_schema.tables` から `pg_tables` に替えたあと、`"holding"` を戻して同じ赤を再確認した。

## 品質ゲート

`pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint` が全パス（テスト234件）。iOS は変更なし（`openapi.yaml` を触っていない）。

## 直さなかった指摘（Minor）

| 指摘 | 直さない理由 |
|---|---|
| 追加したテストは「実在するが監査対象でない名前」（`user` 等）を素通りする | 害は使われない値が1つ増えるだけ。逆向き（監査しているのに一覧に無い）は `src/db/audit.ts` の `AuditTable = Table & { _: { name: AuditResource } }` が型で止める（`"theme_stock"` を消すと `tsc --noEmit` が `src/db/write.ts` で落ちることを確認済み） |
| `schema.ts` のコメントが「読み出しの型も決める」と書くが、`audit_log` を読む本番コードは今1つも無い | 型の性質としては正しく、読む画面を作った日に効く記述のため |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZMSQ17tkQz3HZ5Dr2uBb
