### PR TITLE
[fix] next dev の残骸が品質ゲートとデプロイのビルドを落とす

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -32,7 +32,9 @@
   ],
   // `.next/dev/types` は `next dev` が作るもので、ルートのファイルを消しても
   // そのルートを指す記述が残り、`tsc` と `next build` が両方落ちる（Issue #103）。
-  // 上の include から31行目を消す直し方は採れない。`next dev` が書き戻すため。
+  // 上の include の `".next/dev/types/**/*.ts"` を消す直し方は採れない。
+  // `next dev` が書き戻すため。
   // ここで外しても、同じ検査は `next build` が作る `.next/types` 側で効く。
+  // ただしエディタと、`pnpm build` をまだ一度もしていない環境では効かない。
   "exclude": ["node_modules", ".next/dev"]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -30,5 +30,9 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  // `.next/dev/types` は `next dev` が作るもので、ルートのファイルを消しても
+  // そのルートを指す記述が残り、`tsc` と `next build` が両方落ちる（Issue #103）。
+  // 上の include から31行目を消す直し方は採れない。`next dev` が書き戻すため。
+  // ここで外しても、同じ検査は `next build` が作る `.next/types` 側で効く。
+  "exclude": ["node_modules", ".next/dev"]
 }


### PR DESCRIPTION
Closes #103

`server/tsconfig.json` の `exclude` に `".next/dev"` を1行足した。

## なぜ

`pnpm dev` が作る `server/.next/dev/types/validator.ts` は、ルートのファイルを消しても、そのルートを指す記述が残る。`tsconfig.json` の `include` がここを検査の対象にしていたため、`pnpm typecheck` と `next build` の両方が「無いファイル」を探して落ちていた。

Issue #102（本番へのデプロイ）の `netlify deploy --build --prod` が実際にこれで止まった。

```
.next/dev/types/validator.ts(62,39): error TS2307:
  Cannot find module '../../../app/holdings/[stockId]/page.js'
Failed to type check.
```

消えたルート `app/holdings/[stockId]/page.tsx` は #88 で削除済み。残骸は前日の `pnpm dev` が作ったもの。

## 直した根拠（壊して赤くしたもの）

| 検査 | 修正前 | 修正後 |
|---|---|---|
| 残骸を置いて `pnpm typecheck` | `TS2307` / exit=2 | **exit=0** |
| `app/api/events/route.ts` の `GET` を `(_req: number)` に壊して `pnpm build` | — | **赤**（`.next/types/validator.ts(117,31): error TS2344`） |
| `next dev` を起動して `git diff server/tsconfig.json` | — | **空**（書き戻されない） |
| 品質ゲート（残骸を置いたまま） | — | 全パス（234テスト） |

2つ目が「検出力が落ちていないこと」の根拠。`.next/dev/types` を外しても、同じ契約検査は `next build` が作る `.next/types` 側で効く。

## 採らなかった直し方

独立した2体の討論役で検討し、片方が自分の案を取り下げて収束した。

| 案 | 棄却の理由（実測） |
|---|---|
| `include` から `".next/dev/types/**/*.ts"` を消す | `next dev` が20秒で書き戻し、ファイル全体を再整形する |
| `"build": "rm -rf .next/dev && next build"` | `pnpm typecheck` を単体で叩くと赤のまま。加えて稼働中の `next dev` が `Restarting the server to recover` で落ちて上がり直す |
| `deploy.md` に「詰まったら `rm -rf server/.next/dev`」と書く | 人が読む前提の対処。`pnpm typecheck` の赤は消えない |

## 代償（承知のうえ）

エディタと、まだ一度も `pnpm build` していない環境では、Route Handler の契約検査が効かない。品質ゲートは `pnpm build` → `pnpm typecheck` の順、Netlify も `pnpm gen && pnpm build` なので、ゲートとデプロイの検出力は落ちない。tsconfig のコメントにも書いた。

## 直さずに残した Minor（レビュー指摘）

`include` の `".next/types/**/*.ts"` にも同じ罠が理屈のうえでは残る。ただし `.next/types` を書くのは `next build` だけで、毎回まるごと書き直される。踏むのは「ビルド済み → ルートを消した → ビルドせずに `pnpm typecheck` だけ叩いた」ときで、次のビルドで自然に消える。塞ぐ価値より、tsconfig を読みにくくする害のほうが大きいと判断した。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZMSQ17tkQz3HZ5Dr2uBb
