### PR TITLE
[docs] iPhone への入れ直しを xcodebuild で行う手順に書き換える

### DIFF
--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -185,7 +185,7 @@ nvm use
 
 サーバーだけデプロイしても、iPhone に入っているビルドは古いままである。**入れ直しも手で行う。**
 
-iPhone を Mac に繋いでから、`ios/` で実行する。
+iPhone を Mac に繋いでから、**メインcheckout の** `ios/` で実行する。Worktree から実行すると、配信したサーバーとは別のコードが iPhone に入る。
 
 ```bash
 # 1. 繋がっている実機の Identifier を見る
@@ -194,11 +194,11 @@ xcrun devicectl list devices
 # 2. Release でビルドする（<実機のID> は上で見た Identifier）
 xcodebuild -scheme Ichikabu -configuration Release \
   -destination 'id=<実機のID>' -skipPackagePluginValidation \
-  -derivedDataPath /tmp/ichikabu-release build
+  -derivedDataPath ~/Library/Developer/Xcode/DerivedData/ichikabu-release build
 
 # 3. 実機へ入れる
 xcrun devicectl device install app --device '<実機のID>' \
-  /tmp/ichikabu-release/Build/Products/Release-iphoneos/Ichikabu.app
+  ~/Library/Developer/Xcode/DerivedData/ichikabu-release/Build/Products/Release-iphoneos/Ichikabu.app
 
 # 4. 起動する（iPhone の画面で叩いてもよい）
 xcrun devicectl device process launch --device '<実機のID>' com.takuyaasaoka.ichikabu
@@ -206,11 +206,17 @@ xcrun devicectl device process launch --device '<実機のID>' com.takuyaasaoka.
 
 `-skipPackagePluginValidation` が要る理由は「品質ゲート」の節（`CLAUDE.md`）と同じ。
 
-**`-derivedDataPath` の1回目は数分かかる。** swift-openapi-generator の道具立てを Release で作り直すため。同じパスを次も指せば作り直さない。
+**`-derivedDataPath` の1回目は数分かかる。** swift-openapi-generator の道具立てを Release で作り直すため。同じパスを次も指せば作り直さない。**`/tmp` の下に置かないこと。** macOS が数日で消すため、そのたびに1回目に戻る。
 
 ### Xcode の Scheme を切り替えないこと
 
-同じことは Xcode の **Scheme > Run > Build Configuration** を **Release** にしても行えるが、**この操作は `ios/Ichikabu.xcodeproj/xcshareddata/xcschemes/Ichikabu.xcscheme` を書き換える。** このファイルはコミット対象なので、戻し忘れると Debug 前提の既定が変わったまま入る。上の `xcodebuild -configuration Release` はこのファイルを触らない。
+同じことは Xcode の **Scheme > Run > Build Configuration** を **Release** にしても行えるが、**この操作は `ios/Ichikabu.xcodeproj/xcshareddata/xcschemes/Ichikabu.xcscheme` を書き換える。** このファイルはコミット対象なので、戻し忘れると「既定は Debug」が変わったままコミットに入る。上の `xcodebuild -configuration Release` はこのファイルを触らない。
+
+切り替えてしまったら、こう戻す。
+
+```bash
+git checkout ios/Ichikabu.xcodeproj/xcshareddata/xcschemes/Ichikabu.xcscheme
+```
 
 ### 入ったビルドが本番を見ているかの確かめ方
 

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -174,7 +174,7 @@ nvm use
 
 サンプルの銘柄・イベントも一緒に入る。要らなければ管理UI（`https://ichikabu.netlify.app`）から消す。
 
-## 6. iOS の接続先を切り替える
+## 6. iPhone に配信先を見るビルドを入れる
 
 `ios/Ichikabu/APIClient.swift` の `baseURL` がビルド構成で切り替わる。
 
@@ -183,9 +183,40 @@ nvm use
 | Debug | `http://localhost:3000`（Macの `next dev`） |
 | Release | `https://ichikabu.netlify.app` |
 
-実機で配信先を使うときは、Xcode の **Scheme > Run > Build Configuration** を **Release** にする。Debug のままだと iPhone 自身の3000番を指すため届かない。
+サーバーだけデプロイしても、iPhone に入っているビルドは古いままである。**入れ直しも手で行う。**
 
-**この切り替えは `ios/Ichikabu.xcodeproj/xcshareddata/xcschemes/Ichikabu.xcscheme` を書き換える。** このファイルはコミット対象なので、切り替えたあとは `git checkout` で戻すか、コミットに含めないようにする。既定は Debug のまま置く（開発のほうが回数が多いため）。
+iPhone を Mac に繋いでから、`ios/` で実行する。
+
+```bash
+# 1. 繋がっている実機の Identifier を見る
+xcrun devicectl list devices
+
+# 2. Release でビルドする（<実機のID> は上で見た Identifier）
+xcodebuild -scheme Ichikabu -configuration Release \
+  -destination 'id=<実機のID>' -skipPackagePluginValidation \
+  -derivedDataPath /tmp/ichikabu-release build
+
+# 3. 実機へ入れる
+xcrun devicectl device install app --device '<実機のID>' \
+  /tmp/ichikabu-release/Build/Products/Release-iphoneos/Ichikabu.app
+
+# 4. 起動する（iPhone の画面で叩いてもよい）
+xcrun devicectl device process launch --device '<実機のID>' com.takuyaasaoka.ichikabu
+```
+
+`-skipPackagePluginValidation` が要る理由は「品質ゲート」の節（`CLAUDE.md`）と同じ。
+
+**`-derivedDataPath` の1回目は数分かかる。** swift-openapi-generator の道具立てを Release で作り直すため。同じパスを次も指せば作り直さない。
+
+### Xcode の Scheme を切り替えないこと
+
+同じことは Xcode の **Scheme > Run > Build Configuration** を **Release** にしても行えるが、**この操作は `ios/Ichikabu.xcodeproj/xcshareddata/xcschemes/Ichikabu.xcscheme` を書き換える。** このファイルはコミット対象なので、戻し忘れると Debug 前提の既定が変わったまま入る。上の `xcodebuild -configuration Release` はこのファイルを触らない。
+
+### 入ったビルドが本番を見ているかの確かめ方
+
+`DEBUG` は Debug 構成にしか定義されていない（`ios/Ichikabu.xcodeproj/project.pbxproj` の `SWIFT_ACTIVE_COMPILATION_CONDITIONS`）。したがって Release でビルドすれば `#if DEBUG` の外、つまり配信先を見る。
+
+**画面で確かめるのが確実。** イベントが並べば配信先に届いている。Debug のビルドだと iPhone 自身の3000番を指すため、何も出ない。
 
 ## 7. クレジット残量の見方
 

--- a/ios/Ichikabu/APIClient.swift
+++ b/ios/Ichikabu/APIClient.swift
@@ -14,8 +14,8 @@ enum APIError: Error, Equatable {
 struct APIClient {
 	/// 接続先。Debug はMacの `next dev`、Release は配信先を見る。
 	///
-	/// 実機で配信先を使うときは、Xcode の Scheme > Run > Build Configuration を
-	/// Release にする。Debug のままだと iPhone 自身の 3000 番を指すため届かない。
+	/// 実機へ Release のビルドを入れる手順は `docs/guides/deploy.md` §6。
+	/// Debug のままだと iPhone 自身の 3000 番を指すため届かない。
 	static let baseURL: URL = {
 		#if DEBUG
 			return URL(string: "http://localhost:3000")!


### PR DESCRIPTION
#102 のデプロイで実際に iPhone へ入れ直したときの手順を `docs/guides/deploy.md` §6 に反映した。

## 何を変えたか

| | 前 | 後 |
|---|---|---|
| 手順 | Xcode の Scheme > Run > Build Configuration を Release にする | `xcodebuild -configuration Release` でビルドし `xcrun devicectl` で入れる |
| 副作用 | コミット対象の `Ichikabu.xcscheme` が書き換わる。戻し忘れると「既定は Debug」が変わったまま入る | このファイルを触らない |

## 実測（#102 で実行したもの）

```
xcrun devicectl list devices                        → iPhone 15 Pro が connected
xcodebuild -scheme Ichikabu -configuration Release  → ** BUILD SUCCEEDED **
xcrun devicectl device install app                  → App installed: com.takuyaasaoka.ichikabu
xcrun devicectl device process launch               → Launched
```

iPhone の画面にイベントが並ぶことを利用者が確認済み。

## あわせて足したこと

- 入ったビルドが配信先を見ているかの確かめ方（`DEBUG` は Debug 構成にしか定義されていないので Release なら配信先。ただし**画面で見るのが確実**）
- ビルドの置き場所は `/tmp` に置かない（macOS が数日で消すため、そのたびに1回目の数分に戻る）
- Scheme を切り替えてしまったときの戻し方
- メインcheckout の `ios/` で実行すること（Worktree からだと、配信したサーバーとは別のコードが入る）

`ios/Ichikabu/APIClient.swift` のコメントが Scheme の切り替えを指示したままだったので、deploy.md §6 への参照に置き換えた。**同じ手順が2か所にあると、目に入りやすいコード側が残って事故が再発する。**

## 品質ゲート

```
xcodebuild build test -scheme Ichikabu -destination 'platform=iOS Simulator,name=iPhone 17' -skipPackagePluginValidation
→ ** TEST SUCCEEDED **
```

server 側は触っていない。

## 直さずに残したもの

`docs/records/specs/2026-08-13-74-deploy-target-design.md` の3か所が旧手順のまま。specs は作業記録なので当時のまま凍結する（`docs/` の配置ルールで records は「作業記録」）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZMSQ17tkQz3HZ5Dr2uBb
