### PR TITLE
[test] 一覧と選択肢の並び順を、画面ごとに検査する

### DIFF
--- a/server/app/events/[id]/page.test.ts
+++ b/server/app/events/[id]/page.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EventInput } from "../../../src/db/write";
+import { htmlOf } from "../../../test/dom";
 import { idOf, resetDatabase } from "../../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
 
@@ -96,6 +97,40 @@ describe("イベントの編集画面", () => {
     expect(html).toContain(`<option value="theme:${themeId}" selected="">`);
     expect(html).not.toContain(`<option value="stock:${stockId}" selected="">`);
     expect(html).not.toContain('<option value="market:JP" selected="">');
+  });
+
+  it("対象の選択肢は、テーマ名順・市場ティッカー順に並ぶ", async () => {
+    // テーマと銘柄はこの画面では選択肢にしか出ない。作った順と並び順がずれる
+    // 題材にする。「半導体」「防衛」は、DBの照合順序がどれでも前後が入れ替わらない
+    // 2語（`app/stocks/[id]/page.test.ts` に選んだ経緯がある）
+    await createTheme("防衛");
+    await createTheme("半導体");
+    await createStock({
+      market: "JP",
+      ticker: "7203",
+      name: "トヨタ自動車",
+      fiscalMonth: 3,
+    });
+    await createStock({
+      market: "JP",
+      ticker: "6758",
+      name: "ソニーグループ",
+      fiscalMonth: 3,
+    });
+    const id = await addEvent();
+
+    const html = await render(() => Page({ params: Promise.resolve({ id }) }));
+
+    // 対象は1つの `<select>` に市場・テーマ・銘柄をまとめている。
+    // `<optgroup>` で絞ると、問い合わせ1本ぶんの並びだけを見られる
+    expect(htmlOf(html, 'optgroup[label="テーマ"] option')).toEqual([
+      "半導体",
+      "防衛",
+    ]);
+    expect(htmlOf(html, 'optgroup[label="銘柄"] option')).toEqual([
+      "JP 6758 ソニーグループ",
+      "JP 7203 トヨタ自動車",
+    ]);
   });
 
   it("削除の確認は、消すイベントの題名を出す", async () => {

--- a/server/app/events/page.test.ts
+++ b/server/app/events/page.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { entriesOf, resetDatabase } from "../../test/helpers";
+import { entriesOf, idOf, listItemsOf, resetDatabase } from "../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
 
 const ADMIN = "admin@example.com";
@@ -21,11 +21,11 @@ const { default: Page } = await import("./page");
 type EventInput = Parameters<typeof createEvent>[0];
 
 /** 日経平均を対象にしたイベントの入力。対象の3列は1つだけ埋める（全体設計書 §5） */
-function toInput(shortLabel: string): EventInput {
+function toInput(shortLabel: string, startDate = "2026-09-01"): EventInput {
   return {
     title: `${shortLabel}の発表`,
     shortLabel,
-    startDate: "2026-09-01",
+    startDate,
     endDate: null,
     time: null,
     importance: 3,
@@ -39,8 +39,8 @@ function toInput(shortLabel: string): EventInput {
 }
 
 /** イベントを1件作る */
-async function addEvent(shortLabel: string) {
-  return createEvent(toInput(shortLabel));
+async function addEvent(shortLabel: string, startDate?: string) {
+  return createEvent(toInput(shortLabel, startDate));
 }
 
 /** サインインして、以降の描画がそのセッションで動くようにする */
@@ -60,6 +60,21 @@ beforeEach(async () => {
 // 追い返しと `Nav` の出し分けは `test/pages.test.ts` の表が全画面ぶん見ている。
 // ここに置くのは、この画面にしか無い「入れた人」の出し方だけにする
 describe("イベントの画面", () => {
+  it("イベント一覧は開始日順に並ぶ", async () => {
+    // 日付が先になる回を後から作る。作った順と開始日順が同じ題材だと、
+    // `orderBy(event.startDate)` が落ちても緑のまま通る
+    const later = idOf(await addEvent("CPI", "2026-09-01"));
+    const earlier = idOf(await addEvent("雇用統計", "2026-08-01"));
+    await signIn(EDITOR);
+
+    const html = await render(Page);
+
+    expect(listItemsOf(html)).toEqual([
+      `2026-08-01 ★3 雇用統計<span class="text-muted"> / JP / 雇用統計の発表 / 出典: 表示名なし / 入力: 記録なし</span> <a class="underline" href="/events/${earlier}">編集</a>`,
+      `2026-09-01 ★3 CPI<span class="text-muted"> / JP / CPIの発表 / 出典: 表示名なし / 入力: 記録なし</span> <a class="underline" href="/events/${later}">編集</a>`,
+    ]);
+  });
+
   it("入れた人が名前で出る", async () => {
     await record(userIds.editor, entriesOf(await addEvent("CPI")));
     await signIn(EDITOR);

--- a/server/app/events/page.test.ts
+++ b/server/app/events/page.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { entriesOf, idOf, listItemsOf, resetDatabase } from "../../test/helpers";
+import { htmlOf } from "../../test/dom";
+import { entriesOf, idOf, resetDatabase } from "../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
 
 const ADMIN = "admin@example.com";
@@ -13,7 +14,7 @@ vi.mock("next/headers", () => ({
 const { auth } = await import("../../src/auth");
 const { record } = await import("../../src/db/audit");
 const { seedUser } = await import("../../src/db/seed-user");
-const { createEvent, createTheme, updateEvent } = await import(
+const { createEvent, createStock, createTheme, updateEvent } = await import(
   "../../src/db/write"
 );
 const { default: Page } = await import("./page");
@@ -43,6 +44,11 @@ async function addEvent(shortLabel: string, startDate?: string) {
   return createEvent(toInput(shortLabel, startDate));
 }
 
+/** 銘柄を1件作る */
+async function addStock(ticker: string, name: string) {
+  return createStock({ market: "JP", ticker, name, fiscalMonth: 3 });
+}
+
 /** サインインして、以降の描画がそのセッションで動くようにする */
 async function signIn(email: string): Promise<void> {
   requestHeaders.current = await signInAs(auth.handler, email);
@@ -69,9 +75,33 @@ describe("イベントの画面", () => {
 
     const html = await render(Page);
 
-    expect(listItemsOf(html)).toEqual([
+    expect(htmlOf(html, "li")).toEqual([
       `2026-08-01 ★3 雇用統計<span class="text-muted"> / JP / 雇用統計の発表 / 出典: 表示名なし / 入力: 記録なし</span> <a class="underline" href="/events/${earlier}">編集</a>`,
       `2026-09-01 ★3 CPI<span class="text-muted"> / JP / CPIの発表 / 出典: 表示名なし / 入力: 記録なし</span> <a class="underline" href="/events/${later}">編集</a>`,
+    ]);
+  });
+
+  it("登録フォームの対象は、テーマ名順・市場ティッカー順に並ぶ", async () => {
+    // テーマと銘柄はこの画面では選択肢にしか出ない。作った順と並び順がずれる
+    // 題材にする。「半導体」「防衛」は、DBの照合順序がどれでも前後が入れ替わらない
+    // 2語（`app/stocks/[id]/page.test.ts` に選んだ経緯がある）
+    await createTheme("防衛");
+    await createTheme("半導体");
+    await addStock("7203", "トヨタ自動車");
+    await addStock("6758", "ソニーグループ");
+    await signIn(EDITOR);
+
+    const html = await render(Page);
+
+    // 対象は1つの `<select>` に市場・テーマ・銘柄をまとめている。
+    // `<optgroup>` で絞ると、問い合わせ1本ぶんの並びだけを見られる
+    expect(htmlOf(html, 'optgroup[label="テーマ"] option')).toEqual([
+      "半導体",
+      "防衛",
+    ]);
+    expect(htmlOf(html, 'optgroup[label="銘柄"] option')).toEqual([
+      "JP 6758 ソニーグループ",
+      "JP 7203 トヨタ自動車",
     ]);
   });
 

--- a/server/app/events/page.test.ts
+++ b/server/app/events/page.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { htmlOf } from "../../test/dom";
-import { entriesOf, idOf, resetDatabase } from "../../test/helpers";
+import { entriesOf, resetDatabase } from "../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
 
 const ADMIN = "admin@example.com";
@@ -67,18 +67,29 @@ beforeEach(async () => {
 // ここに置くのは、この画面にしか無い「入れた人」の出し方だけにする
 describe("イベントの画面", () => {
   it("イベント一覧は開始日順に並ぶ", async () => {
-    // 日付が先になる回を後から作る。作った順と開始日順が同じ題材だと、
-    // `orderBy(event.startDate)` が落ちても緑のまま通る
-    const later = idOf(await addEvent("CPI", "2026-09-01"));
-    const earlier = idOf(await addEvent("雇用統計", "2026-08-01"));
+    // 作った順と開始日順がずれる題材にする。同じだと `orderBy(event.startDate)`
+    // が落ちても緑のまま通る。
+    // 4件入れるのは、2件だと落としたときも順番が合ってしまうことがあるため。
+    // 一覧の問い合わせはテーマと銘柄を外部結合しており、`ORDER BY` が無いと
+    // 結合の作りが返す順（作った順でも開始日順でもない）になる。
+    // 2件だとその順がたまたま開始日順と一致した（実測）
+    for (const [shortLabel, startDate] of [
+      ["CPI", "2026-09-01"],
+      ["雇用統計", "2026-08-01"],
+      ["日銀会合", "2026-12-01"],
+      ["GDP", "2026-07-01"],
+    ]) {
+      await addEvent(shortLabel, startDate);
+    }
     await signIn(EDITOR);
 
     const html = await render(Page);
 
-    expect(htmlOf(html, "li")).toEqual([
-      `2026-08-01 ★3 雇用統計<span class="text-muted"> / JP / 雇用統計の発表 / 出典: 表示名なし / 入力: 記録なし</span> <a class="underline" href="/events/${earlier}">編集</a>`,
-      `2026-09-01 ★3 CPI<span class="text-muted"> / JP / CPIの発表 / 出典: 表示名なし / 入力: 記録なし</span> <a class="underline" href="/events/${later}">編集</a>`,
-    ]);
+    // 行の先頭は開始日。ここで見たいのは並び順だけなので先頭だけを比べる。
+    // 行の中身は、この下の「入れた人が名前で出る」以降が見ている
+    expect(
+      htmlOf(html, "li").map((row) => row.slice(0, "2026-08-01".length)),
+    ).toEqual(["2026-07-01", "2026-08-01", "2026-09-01", "2026-12-01"]);
   });
 
   it("登録フォームの対象は、テーマ名順・市場ティッカー順に並ぶ", async () => {

--- a/server/app/page.test.ts
+++ b/server/app/page.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { htmlOf } from "../test/dom";
 import { entriesOf, resetDatabase } from "../test/helpers";
 import { PASSWORD, render, signInAs } from "../test/render-page";
 
@@ -66,6 +67,42 @@ describe("銘柄とテーマの画面", () => {
     expect(html).toContain("半導体");
     expect(html).toContain(`href="/stocks/${stockId}"`);
     expect(html).toContain(`href="/themes/${themeId}"`);
+  });
+
+  it("銘柄・テーマ・テーマ所属が、それぞれ決まった順に並ぶ", async () => {
+    // 3つの問い合わせの並び順をまとめて見る。作った順と並び順がずれる題材に
+    // する。作った順で並べても同じになる題材だと、`orderBy` が落ちても
+    // 緑のまま通る（`app/stocks/[id]/page.test.ts` と同じ考え方）
+    const toyota = await addStock("7203", "トヨタ自動車");
+    const sony = await addStock("6758", "ソニーグループ");
+    // 「半導体」「防衛」は、DBの照合順序がどれでも前後が入れ替わらない2語
+    // （`app/stocks/[id]/page.test.ts` に選んだ経緯がある）
+    await addTheme("防衛");
+    const semiconductor = await addTheme("半導体");
+    entriesOf(await createThemeStock(Number(semiconductor), Number(toyota)));
+    entriesOf(await createThemeStock(Number(semiconductor), Number(sony)));
+
+    const html = await render(Page);
+
+    // 銘柄とテーマは一覧とテーマ所属のフォームの両方に出る。同じ問い合わせから
+    // 出ているので、選択肢の並びを見れば一覧の並びも押さえられる。選択肢で見るのは、
+    // 一覧の `<li>` には「/ 3月決算」や編集リンクが混ざり、並び順と関係ない
+    // 変更で赤くなるため
+    expect(htmlOf(html, 'select[name="stockId"] option')).toEqual([
+      "JP 6758 ソニーグループ",
+      "JP 7203 トヨタ自動車",
+    ]);
+    expect(htmlOf(html, 'select[name="themeId"] option')).toEqual([
+      "半導体",
+      "防衛",
+    ]);
+    // テーマ所属はテーマ一覧の中の入れ子の `<ul>` にしか出ない。
+    // 「防衛」の「銘柄なし」まで並ぶので、テーマの並び順もここに出る
+    expect(htmlOf(html, "ul ul li")).toEqual([
+      `JP 6758 ソニーグループ <a class="underline" href="/themes/${semiconductor}/stocks/${sony}">外す</a>`,
+      `JP 7203 トヨタ自動車 <a class="underline" href="/themes/${semiconductor}/stocks/${toyota}">外す</a>`,
+      "銘柄なし",
+    ]);
   });
 
   it("テーマ所属は所属しているテーマの下にだけぶら下がる", async () => {

--- a/server/app/stocks/[id]/page.test.ts
+++ b/server/app/stocks/[id]/page.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  entriesOf,
-  idOf,
-  listItemsOf,
-  resetDatabase,
-} from "../../../test/helpers";
+import { htmlOf } from "../../../test/dom";
+import { entriesOf, idOf, resetDatabase } from "../../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
 
 const EDITOR = "editor@example.com";
@@ -101,7 +97,7 @@ describe("銘柄の編集画面", () => {
     // 選んでいる（開発用DBが持つ 879 件を総当たりして、逆になるものが0件）。
     // `theme.name` 順は五十音順ではないため、「宇宙」「旅行」のように照合順序で
     // 前後が動く語をここへ足すと、実装が正しくても赤くなる
-    expect(listItemsOf(html)).toEqual(["半導体", "防衛"]);
+    expect(htmlOf(html, "li")).toEqual(["半導体", "防衛"]);
     expect(html).toContain(
       'data-confirm="「トヨタ自動車」を削除する。所属しているテーマ2件も外れる。取り消せない。"',
     );
@@ -112,7 +108,7 @@ describe("銘柄の編集画面", () => {
 
     const html = await render(() => Page({ params: Promise.resolve({ id }) }));
 
-    expect(listItemsOf(html)).toEqual(["所属しているテーマなし"]);
+    expect(htmlOf(html, "li")).toEqual(["所属しているテーマなし"]);
     expect(html).toContain(
       'data-confirm="「トヨタ自動車」を削除する。取り消せない。"',
     );

--- a/server/app/themes/[id]/page.test.ts
+++ b/server/app/themes/[id]/page.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  entriesOf,
-  idOf,
-  listItemsOf,
-  resetDatabase,
-} from "../../../test/helpers";
+import { htmlOf } from "../../../test/dom";
+import { entriesOf, idOf, resetDatabase } from "../../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
 
 const EDITOR = "editor@example.com";
@@ -88,7 +84,7 @@ describe("テーマの編集画面", () => {
 
     const html = await render(() => Page({ params: Promise.resolve({ id }) }));
 
-    expect(listItemsOf(html)).toEqual([
+    expect(htmlOf(html, "li")).toEqual([
       "JP 6758 ソニーグループ",
       "JP 7203 トヨタ自動車",
       "US AAPL Apple",
@@ -103,7 +99,7 @@ describe("テーマの編集画面", () => {
 
     const html = await render(() => Page({ params: Promise.resolve({ id }) }));
 
-    expect(listItemsOf(html)).toEqual(["所属している銘柄なし"]);
+    expect(htmlOf(html, "li")).toEqual(["所属している銘柄なし"]);
     expect(html).toContain(
       'data-confirm="「半導体」を削除する。取り消せない。"',
     );

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.5",
+    "@types/jsdom": "^30.0.0",
     "@types/node": "^24.10.6",
     "@types/pg": "^8.20.4",
     "@types/react": "^19.2.18",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.5
         version: 14.6.5(@testing-library/dom@10.4.1)
+      '@types/jsdom':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^24.10.6
         version: 24.13.3
@@ -1228,6 +1231,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/jsdom@30.0.0':
+    resolution: {integrity: sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -1241,6 +1247,9 @@ packages:
 
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -2088,6 +2097,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
 
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
@@ -2952,6 +2964,13 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/jsdom@30.0.0':
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/tough-cookie': 4.0.5
+      parse5: 8.0.1
+      undici-types: 8.10.0
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -2969,6 +2988,8 @@ snapshots:
   '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3694,6 +3715,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@7.18.2: {}
+
+  undici-types@8.10.0: {}
 
   undici@8.10.0: {}
 

--- a/server/src/status.test.ts
+++ b/server/src/status.test.ts
@@ -59,7 +59,14 @@ describe("次の決算日が未登録", () => {
       startDate: `${LAST_YEAR - 2}-05-01`,
     });
 
+    // ティッカーが先になる 6758 を後から作る。作った順と市場・ティッカー順が
+    // 同じ題材だと、`orderBy` が落ちても緑のまま通る。
+    // JP は数字・US は英字で数字が先に来るため、US を混ぜても第1のキーが
+    // 市場であることは見られない（`app/themes/[id]/page.test.ts` と同じ）
+    await addStock({ ticker: "6758", name: "ソニーグループ" });
+
     expect(await gapsOf("nextEarnings", `${LAST_YEAR - 1}-06-02`)).toEqual([
+      "JP 6758 ソニーグループ",
       "JP 7203 トヨタ自動車",
     ]);
   });
@@ -82,10 +89,20 @@ describe("次の決算日が未登録", () => {
 });
 
 describe("決算月なし", () => {
-  it("決算月が空のJP銘柄が出る", async () => {
+  it("決算月が空のJP銘柄が、ティッカー順に出る", async () => {
     await addStock({ fiscalMonth: null });
+    // ティッカーが先になる 6758 を後から作る。作った順とティッカー順が同じ
+    // 題材だと、`orderBy` が落ちても緑のまま通る
+    await addStock({
+      ticker: "6758",
+      name: "ソニーグループ",
+      fiscalMonth: null,
+    });
 
-    expect(await gapsOf("fiscalMonth")).toEqual(["JP 7203 トヨタ自動車"]);
+    expect(await gapsOf("fiscalMonth")).toEqual([
+      "JP 6758 ソニーグループ",
+      "JP 7203 トヨタ自動車",
+    ]);
   });
 
   it("決算月が入っていれば出ない。US銘柄は決算月が空でも出ない", async () => {
@@ -104,13 +121,21 @@ describe("決算月なし", () => {
 });
 
 describe("出典の表示名なし", () => {
-  it("出典URLはあるが表示名が無い行が出る", async () => {
+  it("出典URLはあるが表示名が無い行が、開始日順に出る", async () => {
     await addEvent({
       title: "消費者物価指数（2027年1月分）",
       sourceUrl: "https://www.stat.go.jp/data/cpi/",
     });
+    // 日付が先になる回を後から作る。作った順と開始日順が同じ題材だと、
+    // `orderBy` が落ちても緑のまま通る
+    await addEvent({
+      title: "消費者物価指数（2026年12月分）",
+      startDate: `${LAST_YEAR}-01-23`,
+      sourceUrl: "https://www.stat.go.jp/data/cpi/",
+    });
 
     expect(await gapsOf("sourceName")).toEqual([
+      `${LAST_YEAR}-01-23 消費者物価指数（2026年12月分）`,
       `${LAST_YEAR}-05-01 消費者物価指数（2027年1月分）`,
     ]);
   });
@@ -127,14 +152,22 @@ describe("出典の表示名なし", () => {
 });
 
 describe("過ぎた非アクティブ", () => {
-  it("非アクティブのまま日付が過ぎた行が出る", async () => {
+  it("非アクティブのまま日付が過ぎた行が、開始日順に出る", async () => {
     await addEvent({
       title: "消費者物価指数（2026年1月分）",
       startDate: `${LAST_YEAR - 2}-01-23`,
       active: false,
     });
+    // 日付が先になる回を後から作る。作った順と開始日順が同じ題材だと、
+    // `orderBy` が落ちても緑のまま通る
+    await addEvent({
+      title: "消費者物価指数（2025年12月分）",
+      startDate: `${LAST_YEAR - 3}-01-23`,
+      active: false,
+    });
 
     expect(await gapsOf("pastInactive")).toEqual([
+      `${LAST_YEAR - 3}-01-23 消費者物価指数（2025年12月分）`,
       `${LAST_YEAR - 2}-01-23 消費者物価指数（2026年1月分）`,
     ]);
   });

--- a/server/src/status.test.ts
+++ b/server/src/status.test.ts
@@ -48,6 +48,13 @@ async function gapsOf(kind: GapKind, today = TODAY): Promise<string[]> {
   return gaps.filter((gap) => gap.kind === kind).map((gap) => gap.label);
 }
 
+// 銘柄を市場・ティッカー順に並べる2つの検査（この下と「決算月なし」）は、
+// 並び順そのものを比べているが、**`orderBy` を落としても赤くならないことがある。**
+// `stock` には `(market, ticker)` の一意索引があり、PostgreSQL がその索引を
+// たどる計画を選ぶと、`ORDER BY` を書かなくても同じ順で返るため
+// （テスト用DBで `Index Scan using stock_market_ticker_unique` を実測。
+// 表を頭から読む計画のときは作った順で返り、赤くなる）。
+// 索引と同じ順に並べる限り、データの選び方では決められない（Issue #130）
 describe("次の決算日が未登録", () => {
   it("今日以降のイベントが無い銘柄が出る", async () => {
     const id = await addStock();

--- a/server/src/status.test.ts
+++ b/server/src/status.test.ts
@@ -3,7 +3,13 @@ import { resetDatabase } from "../test/helpers";
 import { db } from "./db";
 import { event, stock } from "./db/schema";
 import { RIGHTS_YEARS } from "./rights";
-import { findGaps, type GapKind, jstToday } from "./status";
+import {
+  findGaps,
+  type GapKind,
+  jstToday,
+  noFiscalMonthQuery,
+  noNextEarningsQuery,
+} from "./status";
 
 beforeEach(resetDatabase);
 
@@ -48,13 +54,27 @@ async function gapsOf(kind: GapKind, today = TODAY): Promise<string[]> {
   return gaps.filter((gap) => gap.kind === kind).map((gap) => gap.label);
 }
 
-// 銘柄を市場・ティッカー順に並べる2つの検査（この下と「決算月なし」）は、
-// 並び順そのものを比べているが、**`orderBy` を落としても赤くならないことがある。**
+// 銘柄を並べる2つの問い合わせは、**走らせた結果では並び順を守れない。**
 // `stock` には `(market, ticker)` の一意索引があり、PostgreSQL がその索引を
-// たどる計画を選ぶと、`ORDER BY` を書かなくても同じ順で返るため
-// （テスト用DBで `Index Scan using stock_market_ticker_unique` を実測。
-// 表を頭から読む計画のときは作った順で返り、赤くなる）。
-// 索引と同じ順に並べる限り、データの選び方では決められない（Issue #130）
+// たどる計画を選ぶと、`ORDER BY` を書かなくても同じ順で返る（テスト用DBで
+// `Index Scan using stock_market_ticker_unique` を実測）。索引と同じ順に
+// 並べる以上、どんなデータを選んでも消したことに気づけない。
+// そこで問い合わせ文そのものを見る（`src/db/audit.test.ts` の
+// 「並び順は created_at と id の両方で決める」と同じ手。Issue #130）
+describe("銘柄の並び順", () => {
+  it("次の決算日が未登録は、市場・ティッカー順に並べる", () => {
+    expect(noNextEarningsQuery(TODAY).toSQL().sql).toContain(
+      'order by "stock"."market", "stock"."ticker"',
+    );
+  });
+
+  it("決算月なしは、ティッカー順に並べる", () => {
+    expect(noFiscalMonthQuery().toSQL().sql).toContain(
+      'order by "stock"."ticker"',
+    );
+  });
+});
+
 describe("次の決算日が未登録", () => {
   it("今日以降のイベントが無い銘柄が出る", async () => {
     const id = await addStock();

--- a/server/src/status.ts
+++ b/server/src/status.ts
@@ -117,6 +117,8 @@ export function noFiscalMonthQuery() {
 export async function findGaps(today: string): Promise<Gap[]> {
   const year = Number(today.slice(0, 4));
 
+  // この2つだけ関数に切り出してあるのは、並び順を `toSQL()` で見るため。
+  // 残り2つは走らせた結果で守れるので切り出さない
   const noNextEarnings = await noNextEarningsQuery(today);
   const noFiscalMonth = await noFiscalMonthQuery();
 

--- a/server/src/status.ts
+++ b/server/src/status.ts
@@ -58,18 +58,18 @@ export const jstToday = (now: Date): string =>
   now.toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
 
 /**
- * 抜けを全部集める。`today` は日本時間の暦日（`YYYY-MM-DD`）。
+ * 銘柄を対象にした、今日以降のイベントが1件も無い銘柄。
+ * イベントに種別の列は無いため、対象が自分の銘柄で日付が未来のものを決算とみなす
+ * （状態画面 設計書 §2）。
  *
- * 今日を引数で受け取る。中で時計を読むと、日をまたいだ瞬間に結果が変わる判定を
- * テストから固定できない
+ * 組み立てだけを切り出してあるのは、**テストから並び順を確かめるため**
+ * （`src/db/audit.ts` の `recentQuery` と同じ理由）。走らせた結果では
+ * `orderBy` を守れない。`stock` には `(market, ticker)` の一意索引があり、
+ * PostgreSQL がその索引をたどる計画を選ぶと `ORDER BY` を書かなくても
+ * 同じ順で返るため、消しても緑のまま通ることがある（実測）
  */
-export async function findGaps(today: string): Promise<Gap[]> {
-  const year = Number(today.slice(0, 4));
-
-  // 銘柄を対象にした、今日以降のイベントが1件も無い銘柄。
-  // イベントに種別の列は無いため、対象が自分の銘柄で日付が未来のものを決算とみなす
-  // （状態画面 設計書 §2）
-  const noNextEarnings = await db
+export function noNextEarningsQuery(today: string) {
+  return db
     .select({
       id: stock.id,
       market: stock.market,
@@ -91,15 +91,34 @@ export async function findGaps(today: string): Promise<Gap[]> {
       ),
     )
     .orderBy(stock.market, stock.ticker);
+}
 
-  // 決算月が無いJP銘柄。権利付最終日が計算されず、カレンダーに出ない
-  // （`app/api/events/route.ts` の `rightsEvents`）。
-  // US銘柄に決算月は入らない（CHECK 制約 `stock_fiscal_month_market_check`）
-  const noFiscalMonth = await db
+/**
+ * 決算月が無いJP銘柄。権利付最終日が計算されず、カレンダーに出ない
+ * （`app/api/events/route.ts` の `rightsEvents`）。
+ * US銘柄に決算月は入らない（CHECK 制約 `stock_fiscal_month_market_check`）。
+ *
+ * 切り出してある理由は `noNextEarningsQuery` と同じ
+ */
+export function noFiscalMonthQuery() {
+  return db
     .select({ id: stock.id, ticker: stock.ticker, name: stock.name })
     .from(stock)
     .where(and(eq(stock.market, "JP"), isNull(stock.fiscalMonth)))
     .orderBy(stock.ticker);
+}
+
+/**
+ * 抜けを全部集める。`today` は日本時間の暦日（`YYYY-MM-DD`）。
+ *
+ * 今日を引数で受け取る。中で時計を読むと、日をまたいだ瞬間に結果が変わる判定を
+ * テストから固定できない
+ */
+export async function findGaps(today: string): Promise<Gap[]> {
+  const year = Number(today.slice(0, 4));
+
+  const noNextEarnings = await noNextEarningsQuery(today);
+  const noFiscalMonth = await noFiscalMonthQuery();
 
   // 出典URLはあるが表示名が無い行。出典の記載を条件とする出典では規約の条件を
   // 満たさず、`GET /events` が出典を返さない（出典表示 設計書 §3.1）。

--- a/server/test/dom.ts
+++ b/server/test/dom.ts
@@ -1,0 +1,27 @@
+import { JSDOM } from "jsdom";
+
+/**
+ * 画面に出た要素の中身を、出た順にHTMLで取り出す。
+ *
+ * 一覧や選択肢の並び順を見るために使う。`toContain` を並べる形では順不同になり、
+ * 問い合わせから `orderBy` が落ちても緑のまま通る（Issue #128・#130）。
+ *
+ * 使う側は見たい一覧をセレクタで絞る。`app/page.tsx` のようにページに一覧が
+ * 2つ以上あったり、`<ul>` が入れ子になっていたりしても、見たい1つだけを取れる
+ * （`"ul ul li"` で内側の一覧、`'select[name="stockId"] option'` で選択肢）。
+ *
+ * 入れ子のある画面で `"li"` とだけ書くと、外側の `<li>` が内側の `<ul>` を
+ * 丸ごと飲んだ文字列が返る。深さを指定すること
+ *
+ * 返すのは `textContent` ではなく `innerHTML`。`textContent` はタグを落とすため、
+ * 行から編集ページへのリンクが消えて、一覧の検出力が1段落ちる。
+ *
+ * `jsdom` はここでしか読み込まない。多くのテストが読む `test/helpers.ts` に
+ * 置くと、DOMを見ないテストまで jsdom を読むことになる
+ * （21ファイルに読ませた実測で、読み込みが 9.6秒 → 20.4秒）
+ */
+export function htmlOf(html: string, selector: string): string[] {
+  return [...new JSDOM(html).window.document.querySelectorAll(selector)].map(
+    (element) => element.innerHTML,
+  );
+}

--- a/server/test/dom.ts
+++ b/server/test/dom.ts
@@ -16,7 +16,7 @@ import { JSDOM } from "jsdom";
  * 返すのは `textContent` ではなく `innerHTML`。`textContent` はタグを落とすため、
  * 行から編集ページへのリンクが消えて、一覧の検出力が1段落ちる。
  *
- * `jsdom` はここでしか読み込まない。多くのテストが読む `test/helpers.ts` に
+ * `jsdom` を `import` するのはここだけにする。多くのテストが読む `test/helpers.ts` に
  * 置くと、DOMを見ないテストまで jsdom を読むことになる
  * （21ファイルに読ませた実測で、読み込みが 9.6秒 → 20.4秒）
  */

--- a/server/test/helpers.ts
+++ b/server/test/helpers.ts
@@ -71,20 +71,3 @@ export async function expectViolation(
   }
   throw new Error("制約違反になるはずの操作が成功した");
 }
-
-/**
- * 画面に出た `<li>` の中身を、出た順に取り出す。
- *
- * 一覧の並び順を見るために使う。`toContain` を並べる形では順不同になり、
- * 問い合わせから `orderBy` が落ちても緑のまま通る（Issue #128）。
- *
- * ページ全体から拾うため、`<ul>` が2つ以上あるページでは別の一覧の項目まで
- * 混ざる。混ざれば期待する配列と一致せず赤くなるので、黙って別の一覧を
- * 見ていることにはならない。
- *
- * ただし `<ul>` が入れ子になったページ（`app/page.tsx`）には使えない。
- * 外側の `<li>` が内側の `</li>` で閉じたことにされ、中身が途中で切れる
- */
-export function listItemsOf(html: string): string[] {
-  return [...html.matchAll(/<li[^>]*>(.*?)<\/li>/gs)].map((m) => m[1]);
-}


### PR DESCRIPTION
Closes #130

管理画面の問い合わせから `.orderBy(...)` を落としても、テストが緑のまま通る箇所が12あった。`toContain` を並べる形は順不同で、並んでいる行が正しければどの順に出ていても緑になる。12箇所すべてを塞いだ。

## 一覧を見る道具を1本にした

`test/helpers.ts` の `listItemsOf(html)`（正規表現で `<li>` を拾う）を、`test/dom.ts` の `htmlOf(html, セレクタ)`（jsdom）に置き換えた。

`listItemsOf` は `<ul>` が入れ子のページ（`app/page.tsx`）で外側の項目が途中で切れて使えなかった。セレクタで見たい一覧を1つだけ取れる形にすると、入れ子の内側も、画面に一覧として出ない選択肢も、同じ書き方で見られる。

```
htmlOf(html, "ul ul li")                       テーマ所属（入れ子の内側）
htmlOf(html, 'select[name="stockId"] option')  テーマ所属の登録フォームの選択肢
htmlOf(html, 'optgroup[label="テーマ"] option') イベント登録フォームの対象
```

返すのは `textContent` ではなく `innerHTML`。タグを落とすと行から編集ページへのリンクが消え、検出力が1段落ちる。おかげで `listItemsOf` を呼んでいた5箇所は**期待値を1文字も変えずに**そのまま通った。

`jsdom` は `app/form.test.tsx` のために既に devDependency に入っている。今回足したのは型（`@types/jsdom`）だけ。`import` は `test/dom.ts` に閉じた。多くのテストが読む `test/helpers.ts` に置くと、DOMを見ないテストまで jsdom を読む（21ファイルに読ませた実測で、読み込みが 9.6秒 → 20.4秒）。

## 走らせても守れない並び順は、問い合わせ文で見る

`src/status.ts` の銘柄を並べる2本は、**`orderBy` を落としても赤くならないことがあった。** `stock` には `(market, ticker)` の一意索引があり、PostgreSQL がその索引をたどる計画を選ぶと `ORDER BY` を書かなくても同じ順で返る（テスト用DBで `Index Scan using stock_market_ticker_unique` を実測）。索引と同じ順に並べる以上、どんなデータを選んでも決められない。

そこで組み立てを `noNextEarningsQuery` / `noFiscalMonthQuery` に切り出し、`toSQL().sql` を見る。`src/db/audit.ts` の `recentQuery` と `audit.test.ts` の「並び順は created_at と id の両方で決める」が同じ理由で先に取っていた手で、それに揃えた。

イベント一覧（`app/events/page.tsx`）も2件では検出できなかった。一覧はテーマと銘柄を外部結合しており、`ORDER BY` が無いとハッシュ結合が返す順（作った順でも開始日順でもない）になる。2件だとその順がたまたま開始日順と一致した。4件に増やして続けて赤くなることを確認した。

## 塞いだ12箇所

| ファイル | 並べているもの | 対応する検査 |
|---|---|---|
| `app/page.tsx:40` | 銘柄 | `app/page.test.ts`「銘柄・テーマ・テーマ所属が、それぞれ決まった順に並ぶ」 |
| `app/page.tsx:45` | テーマ | 同上 |
| `app/page.tsx:59` | テーマ所属 | 同上 |
| `app/events/page.tsx:35` | 銘柄 | `app/events/page.test.ts`「登録フォームの対象は、テーマ名順・市場ティッカー順に並ぶ」 |
| `app/events/page.tsx:40` | テーマ | 同上 |
| `app/events/page.tsx:65` | イベント | 同「イベント一覧は開始日順に並ぶ」 |
| `app/events/[id]/page.tsx:43` | テーマ | `app/events/[id]/page.test.ts`「対象の選択肢は、テーマ名順・市場ティッカー順に並ぶ」 |
| `app/events/[id]/page.tsx:53` | 銘柄 | 同上 |
| `src/status.ts:93` | 銘柄 | `src/status.test.ts`「次の決算日が未登録は、市場・ティッカー順に並べる」（問い合わせ文） |
| `src/status.ts:102` | 銘柄 | 同「決算月なしは、ティッカー順に並べる」（問い合わせ文） |
| `src/status.ts:111` | イベント | 同「出典URLはあるが表示名が無い行が、開始日順に出る」 |
| `src/status.ts:126` | イベント | 同「非アクティブのまま日付が過ぎた行が、開始日順に出る」 |

題材はどれも、作った順と期待する並び順がずれるものを選んだ。日本語で並べる箇所は「半導体」「防衛」（DBの照合順序が変わっても前後が入れ替わらない2語。PR #129 で選んだ経緯がある）。

## 検証

`orderBy` 13本を全部落として `pnpm test:run` を単独で2回:

```
1回目  11 failed | 359 passed (370)
2回目  10 failed | 360 passed (370)
```

差の1件は「決算月が空のJP銘柄が、ティッカー順に出る」（走らせる検査のほう）で、上に書いた索引の理由で計画しだいに揺れる。ただし同じ `orderBy` を問い合わせ文の検査が2回とも赤にしているので、**13箇所すべてに「必ず赤くなる検査」が対応している。**

> [!NOTE]
> 検出力の確認は必ず単独で流すこと。別のWorktreeと同時に流すと開発用DBを取り合い、本来赤いテストが緑で通る（実測。取り合ったときは90件が無関係に落ちた）。

## 品質ゲート

`pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint` が全パス。373件緑。

## 判断の経緯

入れ子の `<ul>` をどう見るかは、Issue が「実装者に委ねる」としていた点。別コンテキストのエージェント2体で3ラウンド討論し、jsdom 案に収束した。棄却した案と理由:

| 案 | 棄却した理由 |
|---|---|
| `listItemsOf` を正規表現で入れ子に対応させる | 手で書く走査ループが1本増える。既に入っている jsdom を使わない理由が無い |
| `<ul class="pl-4">` を切り出してから拾う | 見た目のクラスに検査が寄りかかる。落ちる理由と直す場所が対応しない |
| `href="/themes/N/stocks/M"` の出現順で見る | 画面に出ている文字を1文字も見ていない |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
