### PR TITLE
[test] イベントと銘柄のテスト用データを1か所にまとめる

### DIFF
--- a/server/app/actions.test.ts
+++ b/server/app/actions.test.ts
@@ -18,6 +18,7 @@ import {
   createThemeStock,
 } from "../src/db/write";
 import { resetDatabase } from "../test/helpers";
+import { eventInput, stockInput } from "../test/inputs";
 import { redirectedTo } from "../test/render-page";
 import { requestHeaders } from "../test/setup";
 import {
@@ -70,28 +71,17 @@ function form(values: Record<string, string>): FormData {
 
 /** 削除の対象を1件ずつ作る。作るのは write 層で、Server Action の権限判定を通さない */
 async function seedTargets(): Promise<void> {
-  await createStock({
-    market: "JP",
-    ticker: "7203",
-    name: "トヨタ自動車",
-    fiscalMonth: 3,
-  });
+  await createStock(stockInput());
   await createTheme("ドローン");
   await createThemeStock(1, 1);
-  await createEvent({
-    title: "日銀の金融政策決定会合",
-    shortLabel: "日銀",
-    startDate: "2026-03-31",
-    endDate: null,
-    time: null,
-    importance: 3,
-    note: null,
-    sourceUrl: null,
-    sourceName: null,
-    market: "JP",
-    themeId: null,
-    stockId: null,
-  });
+  await createEvent(
+    eventInput({
+      title: "日銀の金融政策決定会合",
+      shortLabel: "日銀",
+      startDate: "2026-03-31",
+      market: "JP",
+    }),
+  );
 }
 
 beforeEach(async () => {

--- a/server/app/audit/page.test.ts
+++ b/server/app/audit/page.test.ts
@@ -4,6 +4,7 @@ import { record } from "../../src/db/audit";
 import { seedUser } from "../../src/db/seed-user";
 import { createStock, createTheme } from "../../src/db/write";
 import { entriesOf, resetDatabase } from "../../test/helpers";
+import { stockInput } from "../../test/inputs";
 import {
   PASSWORD,
   redirectedTo,
@@ -52,17 +53,7 @@ describe("監査ログの画面", () => {
 
   it("管理者には日時・操作した人・種別・対象が新しい順に出る", async () => {
     await record(userIds.admin, entriesOf(await createTheme("半導体")));
-    await record(
-      userIds.admin,
-      entriesOf(
-        await createStock({
-          market: "JP",
-          ticker: "7203",
-          name: "トヨタ自動車",
-          fiscalMonth: 3,
-        }),
-      ),
-    );
+    await record(userIds.admin, entriesOf(await createStock(stockInput())));
     await signIn(ADMIN);
 
     const html = await render(Page);

--- a/server/app/events/[id]/page.test.ts
+++ b/server/app/events/[id]/page.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../src/db/write";
 import { htmlOf } from "../../../test/dom";
 import { idOf, resetDatabase } from "../../../test/helpers";
+import { eventInput, stockInput } from "../../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
 import { requestHeaders } from "../../../test/setup";
 import Page from "./page";
@@ -23,20 +24,13 @@ beforeEach(async () => {
 });
 
 /** 空にできる欄をすべて空にしたイベント。埋めたい欄だけ上書きする */
-const MINIMAL: EventInput = {
+const MINIMAL: EventInput = eventInput({
   title: "CPIの発表",
   shortLabel: "CPI",
   startDate: "2026-09-01",
-  endDate: null,
-  time: null,
   importance: 2,
-  note: null,
-  sourceUrl: null,
-  sourceName: null,
   market: "JP",
-  themeId: null,
-  stockId: null,
-};
+});
 
 async function addEvent(overrides: Partial<EventInput> = {}): Promise<string> {
   return idOf(await createEvent({ ...MINIMAL, ...overrides }));
@@ -51,14 +45,7 @@ describe("イベントの編集画面", () => {
 
     // 欄ごとに違う値を入れる。同じ値だと欄を取り違えても気づけない。
     // 対象はテーマにする。市場・銘柄の選択肢も並ぶので、選ばれるのが1つだけであることを見る
-    const stockId = idOf(
-      await createStock({
-        market: "JP",
-        ticker: "7203",
-        name: "トヨタ自動車",
-        fiscalMonth: 3,
-      }),
-    );
+    const stockId = idOf(await createStock(stockInput()));
     const themeId = idOf(await createTheme("半導体"));
     const id = await addEvent({
       title: "半導体関連の決算発表",
@@ -102,12 +89,7 @@ describe("イベントの編集画面", () => {
     // 2語（`app/stocks/[id]/page.test.ts` に選んだ経緯がある）
     await createTheme("防衛");
     await createTheme("半導体");
-    await createStock({
-      market: "JP",
-      ticker: "7203",
-      name: "トヨタ自動車",
-      fiscalMonth: 3,
-    });
+    await createStock(stockInput());
     await createStock({
       market: "JP",
       ticker: "6758",

--- a/server/app/events/[id]/page.test.ts
+++ b/server/app/events/[id]/page.test.ts
@@ -24,7 +24,7 @@ beforeEach(async () => {
 });
 
 /** 空にできる欄をすべて空にしたイベント。埋めたい欄だけ上書きする */
-const MINIMAL: EventInput = eventInput({
+const MINIMAL = eventInput({
   title: "CPIの発表",
   shortLabel: "CPI",
   startDate: "2026-09-01",
@@ -89,13 +89,9 @@ describe("イベントの編集画面", () => {
     // 2語（`app/stocks/[id]/page.test.ts` に選んだ経緯がある）
     await createTheme("防衛");
     await createTheme("半導体");
-    await createStock(stockInput());
-    await createStock({
-      market: "JP",
-      ticker: "6758",
-      name: "ソニーグループ",
-      fiscalMonth: 3,
-    });
+    // 並び順の題材なので、**2件とも**ティッカーと名前を明示する
+    await createStock(stockInput({ ticker: "7203", name: "トヨタ自動車" }));
+    await createStock(stockInput({ ticker: "6758", name: "ソニーグループ" }));
     const id = await addEvent();
 
     const html = await render(() => Page({ params: Promise.resolve({ id }) }));

--- a/server/app/events/page.test.ts
+++ b/server/app/events/page.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/db/write";
 import { htmlOf } from "../../test/dom";
 import { entriesOf, resetDatabase } from "../../test/helpers";
+import { eventInput } from "../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
 import { requestHeaders } from "../../test/setup";
 import Page from "./page";
@@ -21,20 +22,12 @@ type EventInput = Parameters<typeof createEvent>[0];
 
 /** 日経平均を対象にしたイベントの入力。対象の3列は1つだけ埋める（全体設計書 §5） */
 function toInput(shortLabel: string, startDate = "2026-09-01"): EventInput {
-  return {
+  return eventInput({
     title: `${shortLabel}の発表`,
     shortLabel,
     startDate,
-    endDate: null,
-    time: null,
-    importance: 3,
-    note: null,
-    sourceUrl: null,
-    sourceName: null,
     market: "JP",
-    themeId: null,
-    stockId: null,
-  };
+  });
 }
 
 /** イベントを1件作る */

--- a/server/app/status/page.test.ts
+++ b/server/app/status/page.test.ts
@@ -37,8 +37,10 @@ describe("状態の画面", () => {
   it("抜けのある行は直す先へのリンクを出す", async () => {
     // 決算月の無い銘柄は「決算月なし」に出る。行から編集ページへ行ける
     const [created] = entriesOf(
-      // 決算月なしがこのテストの主題。それ以外は既定のまま
-      await createStock(stockInput({ fiscalMonth: null })),
+      // 決算月なしが主題。銘柄名は下で画面に出ているかを見るので明示する
+      await createStock(
+        stockInput({ name: "トヨタ自動車", fiscalMonth: null }),
+      ),
     );
 
     const html = await render(Page);

--- a/server/app/status/page.test.ts
+++ b/server/app/status/page.test.ts
@@ -4,6 +4,7 @@ import { seedUser } from "../../src/db/seed-user";
 import { createStock } from "../../src/db/write";
 import { GAP_KINDS, GAP_TITLES } from "../../src/status";
 import { entriesOf, resetDatabase } from "../../test/helpers";
+import { stockInput } from "../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
 import { requestHeaders } from "../../test/setup";
 import Page from "./page";
@@ -36,12 +37,8 @@ describe("状態の画面", () => {
   it("抜けのある行は直す先へのリンクを出す", async () => {
     // 決算月の無い銘柄は「決算月なし」に出る。行から編集ページへ行ける
     const [created] = entriesOf(
-      await createStock({
-        market: "JP",
-        ticker: "7203",
-        name: "トヨタ自動車",
-        fiscalMonth: null,
-      }),
+      // 決算月なしがこのテストの主題。それ以外は既定のまま
+      await createStock(stockInput({ fiscalMonth: null })),
     );
 
     const html = await render(Page);

--- a/server/app/themes/[id]/stocks/[stockId]/page.test.ts
+++ b/server/app/themes/[id]/stocks/[stockId]/page.test.ts
@@ -31,7 +31,10 @@ describe("テーマ所属を外す画面", () => {
       name: "ソニーグループ",
       fiscalMonth: 3,
     });
-    const stockId = idOf(await createStock(stockInput()));
+    // 銘柄名は下で画面に出ているかを見るので明示する
+    const stockId = idOf(
+      await createStock(stockInput({ name: "トヨタ自動車" })),
+    );
     const themeId = idOf(await createTheme("半導体"));
     entriesOf(await createThemeStock(Number(themeId), Number(stockId)));
 

--- a/server/app/themes/[id]/stocks/[stockId]/page.test.ts
+++ b/server/app/themes/[id]/stocks/[stockId]/page.test.ts
@@ -7,6 +7,7 @@ import {
   createThemeStock,
 } from "../../../../../src/db/write";
 import { entriesOf, idOf, resetDatabase } from "../../../../../test/helpers";
+import { stockInput } from "../../../../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../../../../test/render-page";
 import { requestHeaders } from "../../../../../test/setup";
 import Page from "./page";
@@ -30,14 +31,7 @@ describe("テーマ所属を外す画面", () => {
       name: "ソニーグループ",
       fiscalMonth: 3,
     });
-    const stockId = idOf(
-      await createStock({
-        market: "JP",
-        ticker: "7203",
-        name: "トヨタ自動車",
-        fiscalMonth: 3,
-      }),
-    );
+    const stockId = idOf(await createStock(stockInput()));
     const themeId = idOf(await createTheme("半導体"));
     entriesOf(await createThemeStock(Number(themeId), Number(stockId)));
 

--- a/server/src/db/audit.test.ts
+++ b/server/src/db/audit.test.ts
@@ -23,7 +23,7 @@ import {
 beforeEach(resetDatabase);
 
 /** 市場が JP の市場イベント。対象の3列は1つだけ埋める（→ `test/inputs.ts`） */
-const EVENT: EventInput = eventInput({ market: "JP" });
+const EVENT = eventInput({ market: "JP" });
 
 /** 取り込みが入れる形の市場イベント。名称は STAT_TITLE_PATTERN に当たる */
 function statEvent(overrides: Partial<EventInput> = {}): EventInput {

--- a/server/src/db/audit.test.ts
+++ b/server/src/db/audit.test.ts
@@ -2,6 +2,7 @@ import { getTableColumns } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { STAT_TITLE_PATTERN } from "../../app/stat-schedule";
 import { entriesOf, resetDatabase } from "../../test/helpers";
+import { eventInput, stockInput } from "../../test/inputs";
 import { db } from ".";
 import { listRecent, recentQuery, record } from "./audit";
 import { auditLog, event, stock, theme, themeStock } from "./schema";
@@ -21,20 +22,8 @@ import {
 
 beforeEach(resetDatabase);
 
-const EVENT: EventInput = {
-  title: "日本銀行 金融政策決定会合",
-  shortLabel: "日銀会合",
-  startDate: "2026-09-18",
-  endDate: null,
-  time: null,
-  importance: 3,
-  note: null,
-  sourceUrl: null,
-  sourceName: null,
-  market: "JP",
-  themeId: null,
-  stockId: null,
-};
+/** 市場が JP の市場イベント。対象の3列は1つだけ埋める（→ `test/inputs.ts`） */
+const EVENT: EventInput = eventInput({ market: "JP" });
 
 /** 取り込みが入れる形の市場イベント。名称は STAT_TITLE_PATTERN に当たる */
 function statEvent(overrides: Partial<EventInput> = {}): EventInput {
@@ -163,12 +152,7 @@ describe("削除の記録", () => {
 
   it("銘柄の削除で道連れになるテーマ所属も記録に残る", async () => {
     // theme_stock は CASCADE で一緒に消え、DBに任せると行がどこにも残らない
-    await createStock({
-      market: "JP",
-      ticker: "7203",
-      name: "トヨタ自動車",
-      fiscalMonth: 3,
-    });
+    await createStock(stockInput());
     await createTheme("自動車");
     const [{ id: stockId }] = await db.select().from(stock);
     const [{ id: themeId }] = await db.select().from(theme);
@@ -191,12 +175,7 @@ describe("削除の記録", () => {
   });
 
   it("テーマの削除で道連れになるテーマ所属も記録に残る", async () => {
-    await createStock({
-      market: "JP",
-      ticker: "7203",
-      name: "トヨタ自動車",
-      fiscalMonth: 3,
-    });
+    await createStock(stockInput());
     await createTheme("自動車");
     const [{ id: stockId }] = await db.select().from(stock);
     const [{ id: themeId }] = await db.select().from(theme);
@@ -214,7 +193,10 @@ describe("削除の記録", () => {
 
 describe("更新の記録", () => {
   it("変更前と変更後の両方が残る", async () => {
-    await createEvent(EVENT);
+    // 重要度は 3 → 1 に変える。**このテストが見ている列なので、前の値も
+    // `test/inputs.ts` の既定値に任せず自分で入れる**（既定値を書き換えても
+    // このテストが黙って別のことを確かめる状態にしない）
+    await createEvent({ ...EVENT, importance: 3 });
     const [before] = await db.select().from(event);
 
     await record(

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -15,7 +15,8 @@ const eventBase = {
   importance: 2,
 } as const;
 
-async function createStock(ticker = "7203") {
+/** 既定のティッカーは `test/inputs.ts` から取る（同じ値を2か所に書かない） */
+async function createStock(ticker = stockInput().ticker) {
   const [row] = await db
     .insert(stock)
     .values(stockInput({ ticker }))

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -1,6 +1,7 @@
 import { eq, sql } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { expectViolation, resetDatabase } from "../../test/helpers";
+import { stockInput } from "../../test/inputs";
 import { db } from ".";
 import { AUDIT_RESOURCES, event, stock, theme, themeStock } from "./schema";
 
@@ -17,7 +18,7 @@ const eventBase = {
 async function createStock(ticker = "7203") {
   const [row] = await db
     .insert(stock)
-    .values({ market: "JP", ticker, name: "トヨタ自動車", fiscalMonth: 3 })
+    .values(stockInput({ ticker }))
     .returning();
   return row;
 }

--- a/server/src/db/write.test.ts
+++ b/server/src/db/write.test.ts
@@ -36,7 +36,12 @@ beforeEach(resetDatabase);
 
 describe("createStock", () => {
   it("銘柄を登録するとDBに行が入る", async () => {
-    expect(await createStock({ ...TOYOTA })).toEqual(succeeded);
+    // 渡した値がそのまま列に入ることが主題。**下で突き合わせる2列は、
+    // 既定値に任せずここで渡す**（`test/inputs.ts` の既定を変えても、
+    // このテストは同じことを確かめ続ける）
+    expect(
+      await createStock(stockInput({ ticker: "7203", fiscalMonth: 3 })),
+    ).toEqual(succeeded);
 
     const rows = await db.select().from(stock);
     expect(rows).toHaveLength(1);
@@ -187,7 +192,7 @@ describe("createThemeStock", () => {
 });
 
 /** 対象3列がすべて null の土台。各テストが1列だけ埋める（→ `test/inputs.ts`） */
-const BASE: EventInput = eventInput();
+const BASE = eventInput();
 
 /** イベントの行が1件だけ入ったことを確かめ、その行を返す */
 async function onlyEvent() {
@@ -350,9 +355,13 @@ describe("createEvent", () => {
 });
 
 describe("updateEvent", () => {
-  /** 市場イベントを1件登録し、そのIDを返す */
+  /**
+   * 市場イベントを1件登録し、そのIDを返す。
+   * 短縮ラベルを明示するのは、下の「長すぎる更新は弾かれ**前の値が残る**」が
+   * この値と突き合わせるため（既定値に任せない）
+   */
   async function registerEvent(): Promise<number> {
-    await createEvent({ ...BASE, market: "JP" });
+    await createEvent({ ...BASE, market: "JP", shortLabel: "日銀会合" });
     return (await onlyEvent()).id;
   }
 
@@ -491,9 +500,13 @@ describe("deleteEvent", () => {
   });
 });
 
-/** トヨタを1件だけ登録し、その id を返す */
-async function onlyStockId(): Promise<number> {
-  await createStock({ ...TOYOTA });
+/**
+ * 銘柄を1件だけ登録し、その id を返す。
+ * 銘柄名は、あとで「更新されずに残ったこと」を突き合わせるテストのために
+ * 呼ぶ側から渡せるようにしてある（既定値に任せない）
+ */
+async function onlyStockId(name?: string): Promise<number> {
+  await createStock(name === undefined ? TOYOTA : stockInput({ name }));
   const [row] = await db.select({ id: stock.id }).from(stock);
   return row.id;
 }
@@ -570,7 +583,7 @@ describe("updateStock", () => {
   });
 
   it("空白だけの銘柄名に更新するとエラー文が返る", async () => {
-    const id = await onlyStockId();
+    const id = await onlyStockId("トヨタ自動車");
 
     expect(await updateStock(id, { ...TOYOTA, name: "   " })).toBe(
       "銘柄名を入れる",
@@ -580,7 +593,7 @@ describe("updateStock", () => {
   });
 
   it("存在しないIDの更新は何も起きない", async () => {
-    await onlyStockId();
+    await onlyStockId("トヨタ自動車");
 
     expect(await updateStock(999999, { ...TOYOTA, name: "別名" })).toEqual(
       succeeded,

--- a/server/src/db/write.test.ts
+++ b/server/src/db/write.test.ts
@@ -505,8 +505,8 @@ describe("deleteEvent", () => {
  * 銘柄名は、あとで「更新されずに残ったこと」を突き合わせるテストのために
  * 呼ぶ側から渡せるようにしてある（既定値に任せない）
  */
-async function onlyStockId(name?: string): Promise<number> {
-  await createStock(name === undefined ? TOYOTA : stockInput({ name }));
+async function onlyStockId(name = TOYOTA.name): Promise<number> {
+  await createStock(stockInput({ name }));
   const [row] = await db.select({ id: stock.id }).from(stock);
   return row.id;
 }

--- a/server/src/db/write.test.ts
+++ b/server/src/db/write.test.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { STAT_TITLE_PATTERN } from "../../app/stat-schedule";
 import { resetDatabase } from "../../test/helpers";
+import { eventInput, stockInput } from "../../test/inputs";
 import { db } from ".";
 import { event, stock, theme, themeStock } from "./schema";
 import {
@@ -21,12 +22,8 @@ import {
   upsertMarketEvents,
 } from "./write";
 
-const TOYOTA = {
-  market: "JP",
-  ticker: "7203",
-  name: "トヨタ自動車",
-  fiscalMonth: 3,
-} as const;
+/** 決算月ありのJP銘柄1件。ティッカーと名前を見るテストは自分で渡す（→ `test/inputs.ts`） */
+const TOYOTA = stockInput();
 
 /**
  * 書き込みが成功したことの判定。失敗すると日本語のエラー文（文字列）が返り、
@@ -189,24 +186,8 @@ describe("createThemeStock", () => {
   });
 });
 
-/**
- * 対象3列がすべて null の土台。各テストが1列だけ埋める。
- * 短縮ラベル「日銀会合」は全角4文字（幅8）で、幅の判定には引っかからない
- */
-const BASE: EventInput = {
-  title: "日本銀行 金融政策決定会合",
-  shortLabel: "日銀会合",
-  startDate: "2026-09-18",
-  endDate: null,
-  time: null,
-  importance: 3,
-  note: null,
-  sourceUrl: null,
-  sourceName: null,
-  market: null,
-  themeId: null,
-  stockId: null,
-};
+/** 対象3列がすべて null の土台。各テストが1列だけ埋める（→ `test/inputs.ts`） */
+const BASE: EventInput = eventInput();
 
 /** イベントの行が1件だけ入ったことを確かめ、その行を返す */
 async function onlyEvent() {

--- a/server/src/status.test.ts
+++ b/server/src/status.test.ts
@@ -72,7 +72,8 @@ describe("銘柄の並び順", () => {
 
 describe("次の決算日が未登録", () => {
   it("今日以降のイベントが無い銘柄が出る", async () => {
-    const id = await addStock();
+    // 並び順の題材なので、**2件とも**ティッカーと名前を明示する
+    const id = await addStock({ ticker: "7203", name: "トヨタ自動車" });
     // 過ぎたイベントしか無い銘柄は「次の決算日」が埋まっていない
     await addEvent({ market: null, stockId: id, startDate: `${TODAY}` });
     await addEvent({
@@ -112,7 +113,8 @@ describe("次の決算日が未登録", () => {
 
 describe("決算月なし", () => {
   it("決算月が空のJP銘柄が、ティッカー順に出る", async () => {
-    await addStock({ fiscalMonth: null });
+    // 並び順の題材なので、**2件とも**ティッカーと名前を明示する
+    await addStock({ ticker: "7203", name: "トヨタ自動車", fiscalMonth: null });
     // ティッカーが先になる 6758 を後から作る。作った順とティッカー順が同じ
     // 題材だと、`orderBy` が落ちても緑のまま通る
     await addStock({
@@ -254,7 +256,12 @@ describe("findGaps", () => {
     // イベントは出典の表示名が無いまま非アクティブで日付を過ぎている。
     // 種類をまたいだ並びは `findGaps` の return の順。画面は種類ごとに
     // 取り出すため見た目は変わらないが、ここで固定しておく
-    const stockId = await addStock({ fiscalMonth: null });
+    // 下の期待値に銘柄名が出るので、既定値に任せず明示する
+    const stockId = await addStock({
+      ticker: "7203",
+      name: "トヨタ自動車",
+      fiscalMonth: null,
+    });
     await addEvent({
       title: "消費者物価指数（2026年1月分）",
       startDate: `${LAST_YEAR - 1}-01-23`,

--- a/server/src/status.test.ts
+++ b/server/src/status.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { resetDatabase } from "../test/helpers";
+import { stockInput } from "../test/inputs";
 import { db } from "./db";
 import { event, stock } from "./db/schema";
 import { RIGHTS_YEARS } from "./rights";
@@ -23,13 +24,7 @@ async function addStock(
 ): Promise<number> {
   const [row] = await db
     .insert(stock)
-    .values({
-      market: "JP",
-      ticker: "7203",
-      name: "トヨタ自動車",
-      fiscalMonth: 3,
-      ...values,
-    })
+    .values(stockInput(values))
     .returning({ id: stock.id });
   return row.id;
 }

--- a/server/test/inputs.ts
+++ b/server/test/inputs.ts
@@ -1,4 +1,4 @@
-import type { EventInput } from "../src/db/write";
+import type { EventInput, StockInput } from "../src/db/write";
 
 /**
  * テストが書き込みに渡す入力の作り置き（Issue #139）。
@@ -10,6 +10,17 @@ import type { EventInput } from "../src/db/write";
  * 呼ぶ側に書かせる。既定値の中に隠すと、そのテストが何を確かめているのかが
  * 読めなくなる（並び順を見るテストのティッカー、幅の判定を見るテストの
  * 短縮ラベルなど）。
+ *
+ * **守れているかは、下の既定値を1つずつ書き換えて `pnpm test:run` を流せば分かる。**
+ * 1本でも赤くなったら、そのテストは見ている列をここに隠している。全列で緑に
+ * なることを確かめてある（2026-09-03 実測。7列を1つずつ回して 373件すべて緑。
+ * 最初に回したときは `importance` で1本、`shortLabel` で1本、`ticker` で5本、
+ * `name` で8本、`fiscalMonth` で1本が赤くなり、全部を呼ぶ側に出した）。
+ *
+ * **`{ ticker: undefined }` のように `undefined` を渡さないこと。** 展開が既定値を
+ * `undefined` で上書きするため、NOT NULL 違反になる（この直しの最中に実際に踏んで
+ * 7件落ちた）。省きたい欄は渡さない。省けるようにしたい引数は、
+ * `src/db/schema.test.ts` の `createStock` のように既定値をここから取る。
  *
  * このファイルは型しか読み込まない。多くのテストが読むため、重いものを
  * 足さないこと（`test/dom.ts` の冒頭に、`jsdom` を `test/helpers.ts` に
@@ -52,14 +63,12 @@ export function eventInput(overrides: Partial<EventInput> = {}): EventInput {
  * 列の型どおり `"JP" | "US"` を求めるためである。
  *
  * 狭いほうは広いほうに渡せるので、この型にしておくと
- * `createStock()` と `db.insert(stock)` の**両方**に渡せる
+ * `createStock()` と `db.insert(stock)` の**両方**に渡せる。
+ *
+ * 列を書き写さず `StockInput` から作る。写すと、列が1本増えたときに直す場所が
+ * 2つになり、このファイルを置いた意味が無くなる
  */
-type StockValues = {
-  market: "JP" | "US";
-  ticker: string;
-  name: string;
-  fiscalMonth: number | null;
-};
+type StockValues = StockInput & { market: "JP" | "US" };
 
 /**
  * 銘柄の入力。既定はJPのトヨタ自動車で、決算月あり。

--- a/server/test/inputs.ts
+++ b/server/test/inputs.ts
@@ -1,0 +1,78 @@
+import type { EventInput } from "../src/db/write";
+
+/**
+ * テストが書き込みに渡す入力の作り置き（Issue #139）。
+ *
+ * `EventInput` は12列すべてを埋めないと渡せないため、7本のテストが同じ12行を
+ * 書き写していた。銘柄のほうも同じ1件が11本に散っていた。
+ *
+ * **既定値に隠してよいのは、そのテストが見ていない列だけ。** 見ている列は
+ * 呼ぶ側に書かせる。既定値の中に隠すと、そのテストが何を確かめているのかが
+ * 読めなくなる（並び順を見るテストのティッカー、幅の判定を見るテストの
+ * 短縮ラベルなど）。
+ *
+ * このファイルは型しか読み込まない。多くのテストが読むため、重いものを
+ * 足さないこと（`test/dom.ts` の冒頭に、`jsdom` を `test/helpers.ts` に
+ * 置いたら読み込みが 9.6秒 → 20.4秒 になった実測がある）。
+ */
+
+/**
+ * イベントの入力。**対象の3列はすべて null**で、埋めるのは呼ぶ側。
+ *
+ * 3列のうちちょうど1つだけが非NULLであることは DB の
+ * `event_target_exclusive_check` が判定する（全体設計書 §5）。既定でどれかを
+ * 埋めておくと、「対象を1つも選ばない」を確かめるテストが書けなくなる。
+ *
+ * 短縮ラベル「日銀会合」は全角4文字（幅8）で、幅の上限10には引っかからない。
+ */
+export function eventInput(overrides: Partial<EventInput> = {}): EventInput {
+  return {
+    title: "日本銀行 金融政策決定会合",
+    shortLabel: "日銀会合",
+    startDate: "2026-09-18",
+    endDate: null,
+    time: null,
+    importance: 3,
+    note: null,
+    sourceUrl: null,
+    sourceName: null,
+    market: null,
+    themeId: null,
+    stockId: null,
+    ...overrides,
+  };
+}
+
+/**
+ * 銘柄の列に入れる値。**`market` を `"JP" | "US"` に狭めてある。**
+ *
+ * `StockInput` の `market` は `string`。画面から来た値を絞り込まずDBの
+ * `stock_market_check` に判定させるためで、あれは正しい（`src/db/write.ts`）。
+ * だがそのままだと `db.insert(stock).values()` に渡せない。Drizzle 側は
+ * 列の型どおり `"JP" | "US"` を求めるためである。
+ *
+ * 狭いほうは広いほうに渡せるので、この型にしておくと
+ * `createStock()` と `db.insert(stock)` の**両方**に渡せる
+ */
+type StockValues = {
+  market: "JP" | "US";
+  ticker: string;
+  name: string;
+  fiscalMonth: number | null;
+};
+
+/**
+ * 銘柄の入力。既定はJPのトヨタ自動車で、決算月あり。
+ *
+ * 決算月は JP 銘柄にしか入らない（CHECK 制約 `stock_fiscal_month_market_check`）。
+ * US 銘柄を作るときは `market` と一緒に `fiscalMonth: null` も渡すこと
+ */
+export function stockInput(overrides: Partial<StockValues> = {}): StockValues {
+  return {
+    market: "JP",
+    ticker: "7203",
+    name: "トヨタ自動車",
+    fiscalMonth: 3,
+    ...overrides,
+  };
+}

--- a/server/test/pages.test.ts
+++ b/server/test/pages.test.ts
@@ -22,6 +22,7 @@ import {
   createThemeStock,
 } from "../src/db/write";
 import { entriesOf, idOf, resetDatabase } from "./helpers";
+import { eventInput } from "./inputs";
 import {
   expectNotFound,
   PASSWORD,
@@ -53,20 +54,14 @@ async function addTheme(name = "半導体") {
 
 async function addEvent(): Promise<string> {
   return idOf(
-    await createEvent({
-      title: "CPIの発表",
-      shortLabel: "CPI",
-      startDate: "2026-09-01",
-      endDate: null,
-      time: null,
-      importance: 3,
-      note: null,
-      sourceUrl: null,
-      sourceName: null,
-      market: "JP",
-      themeId: null,
-      stockId: null,
-    }),
+    await createEvent(
+      eventInput({
+        title: "CPIの発表",
+        shortLabel: "CPI",
+        startDate: "2026-09-01",
+        market: "JP",
+      }),
+    ),
   );
 }
 


### PR DESCRIPTION
Closes #139

## 何をしたか

7本のテストが書き写していたイベントの12列と、11本に散っていた同じ銘柄1件を `server/test/inputs.ts` の `eventInput()` / `stockInput()` にまとめた。各テストは変えたい列だけを渡す。

イベントの対象3列は既定ですべて `null` にした。ちょうど1つだけ非NULLであることは DB の `event_target_exclusive_check` が判定するので、既定でどれかを埋めると「対象を1つも選ばない」を確かめるテストが書けなくなる。

`stockInput` の戻り値は `StockInput & { market: "JP" | "US" }`。`StockInput.market` は `string`（画面から来た値を絞り込まずDBに判定させるため。それは正しい）だが、そのままでは `db.insert(stock).values()` に渡せない。狭いほうは広いほうに渡せるので、この型なら `createStock()` と直接の insert の両方に渡せる。列を書き写さず `StockInput` から作っているので、列が1本増えても直す場所は1つ。

## 壊して赤くなることの確認（ここが本題）

**既定値を1つずつ書き換えて全件を流した。赤くなったら、そのテストは「見ている列」を作り置きに隠している。**

| 変異した列 | 最初 | 直した後 |
|---|---|---|
| `title` | 373 passed | 373 passed |
| `shortLabel` | **1 failed** | 373 passed |
| `startDate` | 373 passed | 373 passed |
| `importance` | **1 failed** | 373 passed |
| `ticker` | **5 failed** | 373 passed |
| `name` | **8 failed** | 373 passed |
| `fiscalMonth` | **1 failed** | 373 passed |

**最初は `importance` の1列しか回しておらず、残り6列を確かめていなかった。** レビューで指摘されて全列を回したところ、計15本が「そのテストが見ている列を既定値に隠している」状態だった。全部を呼ぶ側に出した。

- `write.test.ts` の `createStock` — 渡した `ticker`・`fiscalMonth` がそのまま列に入ることが主題。突き合わせる2列を呼び出しで渡す
- `write.test.ts` の `registerEvent` — 長すぎる短縮ラベルへの更新が弾かれて**前の値が残る**ことを見るので、その前の値を明示
- `write.test.ts` の `onlyStockId` — 更新が起きず前の名前が残ることを見る2本のため、銘柄名を引数で受け取る
- `status.test.ts` の並び順3本、`events/[id]`・`status`・`themes` の画面3本 — 並びの題材や画面に出る文字列を**2件とも**明示

**逆向きも確かめた**（レビュー役が独立に実行）。`write.ts` の `trimmedName` と `tooLongLabel` を壊すと6本、`status.ts` の `orderBy` を反転させると3本が今も赤くなる。緑にするために期待値を緩めた箇所は無い。

この判定手順そのものを `test/inputs.ts` の冒頭に実測日つきで残した。次に列を足す人が同じ手を打てる。

## 置き換えなかった3本

**基準は「その列がそのテストの主題かどうか」。** 主題なら呼ぶ側に書かせる（＝作り置きを使わない）。

| ファイル | 残した理由 |
|---|---|
| `app/bulk-event-input.test.ts` | 当たる12列は `toEqual` の**期待値**で、入力ではない。作り置きに置き換えると、検査が自分と同じ既定値を突き合わせることになり、既定値を書き換えたときに一緒に動いて緑のまま通る（`test/helpers.ts` の `expectPublicApiCacheHeaders` と同じ理由） |
| `app/api/stocks/route.test.ts` | 市場とティッカーの並び順そのものが主題。呼ぶ側に書かせる |
| `app/api/events/route.test.ts` | 期待値が `title: "トヨタ自動車 権利付最終日"` / `shortLabel: "7203権利"` / `startDate: "2026-03-27"`（決算月3から計算した日）で、**ティッカー・銘柄名・決算月の3列すべてが主題**。作り置きにしても同じ内容を書き直すだけで、行数も読みやすさも変わらない |

検証コマンド（`--include='*.test.ts'` で絞っているため `test/inputs.ts` は構造上ヒットしない）を再実行すると、当たるのはこの3ファイルになる。これが最終形。

```
イベントの12列を直に書くテスト:
app/bulk-event-input.test.ts
トヨタ自動車の銘柄を直に書くテスト:
app/api/events/route.test.ts
app/api/stocks/route.test.ts
```

## 途中で踏んだ罠

`createStock(ticker?: string)` から `stockInput({ ticker })` を呼ぶ形にしたら、`src/db/schema.test.ts` が7件落ちた。展開が既定値を `undefined` で上書きして NOT NULL 違反になる。`createStock(ticker = stockInput().ticker)` に直し、次の人が踏まないよう `test/inputs.ts` に断りを足した。

## 効果（正直な数字）

**当初の見込みは −60行だったが、実測は −21行。**

| 内訳 | 行数 |
|---|---|
| テスト11本 | −99 |
| `test/inputs.ts`（新規） | +78 |
| **差引** | **−21** |

行数の改善は小さい。効いたのは、**変異スイープで15本の「見ている列を隠していたテスト」を洗い出せたこと**のほうで、これは作り置きを作らなければ気づけなかった。

## 品質ゲート

```
$ pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint
Test Files  30 passed (30)
     Tests  373 passed (373)
Checked 96 files in 97ms. No fixes applied.
```

この Worktree は `TEST_DATABASE_URL` を `ichikabu_test_139` に向けてある（`.env.local` はコミット対象外）。共有DBに他の実行が当たると互いのデータを消し合うため（`CLAUDE.md`）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PnUjseR21HBWSE9siKbKj
