### PR TITLE
[refactor] サインインの確認とIDの確認を app/guard.ts に寄せる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Claude Code の作業ディレクトリ（worktree を .claude/worktrees/ 配下に作る運用のため）
 .claude/worktrees/
 
+# 依存の実物。pnpm は server/ の中だけで回すが、最上位から vitest 等を叩くと
+# ここにも node_modules/.vite/ ができる。server/.gitignore だけでは最上位を
+# 覆えないため、こちらにも書く（Issue #140 で実際に1ファイル紛れ込んだ）
+node_modules/
+
 # 実装計画を進めるときの作業メモ（進捗台帳・レビュー用の差分ファイル）
 .superpowers/
 

--- a/docs/records/specs/2026-08-14-82-multi-editor-audit-design.md
+++ b/docs/records/specs/2026-08-14-82-multi-editor-audit-design.md
@@ -45,9 +45,9 @@
 
 `server/app/actions.ts` の削除は5つ（銘柄・保有・テーマ・テーマ所属・イベント）。今はどれも `requireUserId()` を呼ぶだけで、サインインしていれば誰でも実行できる。
 
-`requireUserId()` の隣に管理者を確かめる関数を置き、**削除5つのうち4つ**（銘柄・テーマ・テーマ所属・イベント）がそれを呼ぶ。保有を外すのは含めない（理由はこの節の末尾）。
+`requireUserId()`（Issue #140 で `server/app/guard.ts` へ移した）を呼ぶ側、つまり `server/app/actions.ts` に管理者を確かめる関数を置き、**削除5つのうち4つ**（銘柄・テーマ・テーマ所属・イベント）がそれを呼ぶ。保有を外すのは含めない（理由はこの節の末尾）。
 
-**画面から削除のリンクを消すだけでは足りない。** Server Action は画面を通さず直接POSTできる（`server/app/actions.ts` の `requireSession` に書いた注記と同じ理由）。判定はサーバー側で行い、テストも Server Action を直接呼ぶ形で書く。
+**画面から削除のリンクを消すだけでは足りない。** Server Action は画面を通さず直接POSTできる（`server/app/guard.ts` の `requireSession` に書いた注記と同じ理由。Issue #140 で `app/actions.ts` から移した。画面も同じ判定を通すため）。判定はサーバー側で行い、テストも Server Action を直接呼ぶ形で書く。
 
 管理者かどうかは、環境変数 `ADMIN_EMAIL` とセッションのメールアドレスを比べて決める。両方を小文字にしてから比べる（`seedUser` がメールアドレスを小文字にして入れるため、揃えないと設定に大文字が1つ入っただけで管理者が誰も居なくなる）。`ADMIN_EMAIL` が未設定なら `app/actions.ts` が読み込みの時点で落ちる。
 

--- a/server/app/actions.ts
+++ b/server/app/actions.ts
@@ -1,10 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { isAdmin } from "../src/admin";
-import { auth } from "../src/auth";
 import { db } from "../src/db";
 import { record } from "../src/db/audit";
 import { stock, theme } from "../src/db/schema";
@@ -26,30 +24,10 @@ import {
 } from "../src/db/write";
 import { toEventInputs } from "./bulk-event-input";
 import { toEventInput } from "./event-input";
+import { requireSession, requireUserId, type Session } from "./guard";
 
 // サインインはここに置かない。ブラウザから Better Auth の HTTP エンドポイントを
 // 叩く（app/signin/signin-form.tsx）。auth.api の直接呼び出しは回数制限を通らないため（設計書 §6）
-
-/**
- * サインインしているかを確かめてセッションを返す。
- * Server Action は画面を通さず直接POSTできるため、画面側の確認とは別にここでも確かめる
- * （Next.js 同梱ドキュメント 01-app/01-getting-started/07-mutating-data.md の警告）
- */
-async function requireSession(): Promise<Session> {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
-  return session;
-}
-
-/** サインインしている利用者。監査ログに残す利用者IDの出どころでもある */
-type Session = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
-
-/** セッションを確かめて利用者IDを返す */
-async function requireUserId(): Promise<string> {
-  return (await requireSession()).user.id;
-}
 
 /**
  * 管理者かどうかを確かめる。管理者なら null、そうでなければ拒む理由を返す。

--- a/server/app/audit/page.tsx
+++ b/server/app/audit/page.tsx
@@ -1,12 +1,9 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import { isAdmin } from "../../src/admin";
-import { auth } from "../../src/auth";
 import {
   type AuditAction,
   type AuditResource,
   listRecent,
 } from "../../src/db/audit";
+import { requireAdminSession } from "../guard";
 import { Nav } from "../nav";
 
 /** 操作の区分の見出し。足し忘れは Record の型が落とす */
@@ -39,15 +36,9 @@ const formatJst = (at: Date): string =>
  * 並び順の判定をここに書くと、DBを繋いで確かめる場所が無くなる
  */
 export default async function Page() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
-  // 画面から入口を消すだけでは足りない。URL を直に打てば開ける。
-  // `redirect` で追い返す。ここで止めれば、下の読み出しに進めない
-  if (!isAdmin(session.user.email)) {
-    redirect("/");
-  }
+  // 管理者でなければ追い返す。画面から入口を消すだけでは足りない
+  // （URL を直に打てば開ける。→ `app/guard.ts`）
+  const session = await requireAdminSession();
 
   const rows = await listRecent();
 

--- a/server/app/contributions/page.tsx
+++ b/server/app/contributions/page.tsx
@@ -1,7 +1,5 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import { auth } from "../../src/auth";
 import { countByUser } from "../../src/db/audit";
+import { requireSession } from "../guard";
 import { Nav } from "../nav";
 
 /**
@@ -14,10 +12,7 @@ import { Nav } from "../nav";
  * 監査ログ（前後の値まで出る）とは見えるものの重さが違う
  */
 export default async function Page() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
   const rows = await countByUser();
   // 取り込みスクリプトの行も1行返るが、人ではないので人数には数えない

--- a/server/app/events/[id]/page.tsx
+++ b/server/app/events/[id]/page.tsx
@@ -1,13 +1,11 @@
 import { eq } from "drizzle-orm";
-import { headers } from "next/headers";
-import { notFound, redirect } from "next/navigation";
-import { auth } from "../../../src/auth";
+import { notFound } from "next/navigation";
 import { db } from "../../../src/db";
 import { event, stock, theme } from "../../../src/db/schema";
-import { isId } from "../../../src/db/write";
 import { editEvent, removeEvent } from "../../actions";
 import { EventForm } from "../../event-form";
 import { ActionForm } from "../../form";
+import { requireId, requireSession } from "../../guard";
 import { Nav } from "../../nav";
 
 /**
@@ -19,18 +17,10 @@ export default async function Page({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
-  // 問い合わせに渡せないIDは、integer 列に渡す前に弾く。渡すと型変換エラーで
-  // 500 になる。判定は Server Action と同じものを使う（設計書 §6）
   const { id } = await params;
-  const eventId = Number(id);
-  if (!isId(eventId)) {
-    notFound();
-  }
+  const eventId = requireId(id);
 
   const [row] = await db.select().from(event).where(eq(event.id, eventId));
   if (!row) {

--- a/server/app/events/page.tsx
+++ b/server/app/events/page.tsx
@@ -1,14 +1,12 @@
 import { eq } from "drizzle-orm";
-import { headers } from "next/headers";
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { auth } from "../../src/auth";
 import { db } from "../../src/db";
 import { creatorNamesByEventId } from "../../src/db/audit";
 import { event, stock, theme } from "../../src/db/schema";
 import { addEvent } from "../actions";
 import { BulkEventForm } from "../bulk-event-form";
 import { EventForm } from "../event-form";
+import { requireSession } from "../guard";
 import { Nav } from "../nav";
 
 /**
@@ -17,10 +15,7 @@ import { Nav } from "../nav";
  * 並べ替え・絞り込みは付けない
  */
 export default async function Page() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
   // 登録フォームの対象の選択肢。イベントは銘柄かテーマかマーケットに紐づく
   const stocks = await db

--- a/server/app/guard.ts
+++ b/server/app/guard.ts
@@ -1,0 +1,88 @@
+import { headers } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import { isAdmin } from "../src/admin";
+import { auth } from "../src/auth";
+import { isId } from "../src/db/write";
+
+// 画面と Server Action が最初に通す判定（Issue #140）。
+//
+// ここに置く前は、9枚の画面が同じ4行を、4枚が同じ5行を書き写していた。
+// 書き写す形だと、画面を1枚足したときに書き忘れてもエラーにならず、
+// サインインしていない人に中身が見える画面が黙って1枚増える。
+//
+// **レイアウト（`app/(admin)/layout.tsx`）にはしない。** 画面のテストは
+// `renderToStaticMarkup(await Page())` で描いており（`test/render-page.ts` の
+// `render`）、レイアウトは Next.js のルーターが合成するためこの呼び方では
+// 一度も描かれない。判定がテストの届かない場所へ移る
+// （管理画面を分ける設計書 §3 が実測で棄却済み）。
+// 画面が自分で呼ぶ関数なら、今のテストがそのまま判定を見られる。
+//
+// `app/actions.ts` には置けない。あのファイルは "use server" で、公開できるのは
+// 非同期の関数だけ（Next.js 同梱ドキュメント
+// 01-app/01-getting-started/07-mutating-data.md）。`src/admin.ts` の `isAdmin` を
+// 外に出してあるのと同じ理由
+
+/** サインインしている利用者。監査ログに残す利用者IDの出どころでもある */
+export type Session = NonNullable<
+  Awaited<ReturnType<typeof auth.api.getSession>>
+>;
+
+/**
+ * サインインしているかを確かめてセッションを返す。していなければサインイン画面へ送る。
+ *
+ * **画面と Server Action の両方がこれを通る。** Server Action は画面を通さず
+ * 直接POSTできるため、画面側の確認とは別に Server Action でも確かめる
+ * （Next.js 同梱ドキュメント 01-app/01-getting-started/07-mutating-data.md の警告。
+ * → 監査ログ 設計書 §4）。
+ *
+ * `app/signin/page.tsx` はこれを使わない。あの画面は「サインイン**済み**なら
+ * 追い返す」という逆の判定で、行き先も違う
+ */
+export async function requireSession(): Promise<Session> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    redirect("/signin");
+  }
+  return session;
+}
+
+/** セッションを確かめて利用者IDを返す */
+export async function requireUserId(): Promise<string> {
+  return (await requireSession()).user.id;
+}
+
+/**
+ * 管理者だけが開ける画面で使う。管理者でなければ管理画面へ追い返す。
+ *
+ * **Server Action の管理者の判定とは別にする。** あちらは `redirect()` にせず
+ * エラー文を返す（理由は `app/actions.ts` の `requireAdmin` に書いた）。
+ *
+ * 画面のほうは追い返して構わない。開いただけで何も起きないため、
+ * 拒否と成功を見分ける必要が無い。
+ *
+ * 画面から入口を消すだけでは足りない。URL を直に打てば開ける。
+ * ここで止めれば、呼んだ画面は下の読み出しに進めない
+ */
+export async function requireAdminSession(): Promise<Session> {
+  const session = await requireSession();
+  if (!isAdmin(session.user.email)) {
+    redirect("/");
+  }
+  return session;
+}
+
+/**
+ * URL のIDを数にして返す。問い合わせに渡せない値なら見つからない扱いにする。
+ *
+ * 画面やURLから来る id は文字列で、`Number()` が NaN や integer の範囲外の数を
+ * 返すことがある。それをそのまま integer 列に渡すと、制約違反ではない
+ * 型変換エラーになり、日本語化を通らず 500 になる
+ * （イベントの編集・削除 設計書 §6）。判定は Server Action と同じ `isId` を使う
+ */
+export function requireId(raw: string): number {
+  const id = Number(raw);
+  if (!isId(id)) {
+    notFound();
+  }
+  return id;
+}

--- a/server/app/page.tsx
+++ b/server/app/page.tsx
@@ -1,11 +1,9 @@
 import { eq } from "drizzle-orm";
-import { headers } from "next/headers";
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { auth } from "../src/auth";
 import { db } from "../src/db";
 import { stock, theme, themeStock } from "../src/db/schema";
 import { addStock, addTheme } from "./actions";
+import { requireSession } from "./guard";
 import { Nav } from "./nav";
 import { StockForm } from "./stock-form";
 import { ThemeForm } from "./theme-form";
@@ -23,10 +21,7 @@ import { ThemeStockForm } from "./theme-stock-form";
  * ここを指しているため
  */
 export default async function Page() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
   const stocks = await db
     .select({

--- a/server/app/status/page.tsx
+++ b/server/app/status/page.tsx
@@ -1,8 +1,6 @@
-import { headers } from "next/headers";
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { auth } from "../../src/auth";
 import { findGaps, GAP_KINDS, GAP_TITLES, jstToday } from "../../src/status";
+import { requireSession } from "../guard";
 import { Nav } from "../nav";
 
 /**
@@ -12,10 +10,7 @@ import { Nav } from "../nav";
  * （画面そのものも検査できる。→ `src/status.ts` の注記）
  */
 export default async function Page() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
   const gaps = await findGaps(jstToday(new Date()));
 

--- a/server/app/stocks/[id]/page.tsx
+++ b/server/app/stocks/[id]/page.tsx
@@ -1,12 +1,10 @@
 import { eq } from "drizzle-orm";
-import { headers } from "next/headers";
-import { notFound, redirect } from "next/navigation";
-import { auth } from "../../../src/auth";
+import { notFound } from "next/navigation";
 import { db } from "../../../src/db";
 import { stock, theme, themeStock } from "../../../src/db/schema";
-import { isId } from "../../../src/db/write";
 import { editStock, removeStock } from "../../actions";
 import { ActionForm } from "../../form";
+import { requireId, requireSession } from "../../guard";
 import { Nav } from "../../nav";
 import { StockForm } from "../../stock-form";
 
@@ -19,18 +17,10 @@ export default async function Page({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
-  // 問い合わせに渡せないIDは、integer 列に渡す前に弾く。渡すと型変換エラーで
-  // 500 になる。判定は Server Action と同じものを使う（イベントの編集・削除 設計書 §6）
   const { id } = await params;
-  const stockId = Number(id);
-  if (!isId(stockId)) {
-    notFound();
-  }
+  const stockId = requireId(id);
 
   const [row] = await db.select().from(stock).where(eq(stock.id, stockId));
   if (!row) {

--- a/server/app/themes/[id]/page.tsx
+++ b/server/app/themes/[id]/page.tsx
@@ -1,12 +1,10 @@
 import { eq } from "drizzle-orm";
-import { headers } from "next/headers";
-import { notFound, redirect } from "next/navigation";
-import { auth } from "../../../src/auth";
+import { notFound } from "next/navigation";
 import { db } from "../../../src/db";
 import { stock, theme, themeStock } from "../../../src/db/schema";
-import { isId } from "../../../src/db/write";
 import { editTheme, removeTheme } from "../../actions";
 import { ActionForm } from "../../form";
+import { requireId, requireSession } from "../../guard";
 import { Nav } from "../../nav";
 import { ThemeForm } from "../../theme-form";
 
@@ -19,18 +17,10 @@ export default async function Page({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
-  // 問い合わせに渡せないIDは、integer 列に渡す前に弾く。渡すと型変換エラーで
-  // 500 になる。判定は Server Action と同じものを使う（イベントの編集・削除 設計書 §6）
   const { id } = await params;
-  const themeId = Number(id);
-  if (!isId(themeId)) {
-    notFound();
-  }
+  const themeId = requireId(id);
 
   const [row] = await db.select().from(theme).where(eq(theme.id, themeId));
   if (!row) {

--- a/server/app/themes/[id]/stocks/[stockId]/page.tsx
+++ b/server/app/themes/[id]/stocks/[stockId]/page.tsx
@@ -1,12 +1,10 @@
 import { and, eq } from "drizzle-orm";
-import { headers } from "next/headers";
-import { notFound, redirect } from "next/navigation";
-import { auth } from "../../../../../src/auth";
+import { notFound } from "next/navigation";
 import { db } from "../../../../../src/db";
 import { stock, theme, themeStock } from "../../../../../src/db/schema";
-import { isId } from "../../../../../src/db/write";
 import { removeThemeStock } from "../../../../actions";
 import { ActionForm } from "../../../../form";
+import { requireId, requireSession } from "../../../../guard";
 import { Nav } from "../../../../nav";
 
 /**
@@ -19,18 +17,12 @@ export default async function Page({
 }: {
   params: Promise<{ id: string; stockId: string }>;
 }) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect("/signin");
-  }
+  const session = await requireSession();
 
   // 複合主キーなので2列とも判定する（設計書 §4）
   const { id, stockId: rawStockId } = await params;
-  const themeId = Number(id);
-  const stockId = Number(rawStockId);
-  if (!isId(themeId) || !isId(stockId)) {
-    notFound();
-  }
+  const themeId = requireId(id);
+  const stockId = requireId(rawStockId);
 
   const [row] = await db
     .select({

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -15,8 +15,8 @@ if (!adminEmail) {
  *
  * `app/actions.ts` に置かない。あのファイルは "use server" で、公開できるのは
  * 非同期の関数だけ（Next.js 同梱ドキュメント 01-app/01-getting-started/07-mutating-data.md）。
- * 監査ログの画面（`app/audit/page.tsx`）も同じ判定が要るため、両方から読める場所へ出す。
- * 判定を画面側で書き写すと、管理者の決め方が2か所になってズレる
+ * 画面側の判定（`app/guard.ts` の `requireAdminSession`）も同じものが要るため、
+ * 両方から読める場所へ出す。判定を書き写すと、管理者の決め方が2か所になってズレる
  */
 export function isAdmin(email: string): boolean {
   // seedUser がメールアドレスを小文字にして入れるため、比較も小文字で揃える

--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -35,7 +35,7 @@ const ALLOWED_DIRECT_WRITERS = [
 
 /**
  * 書き込み関数ではない値の export。読み込んでも実データは変わらないため、
- * どのファイルから読んでもよい（`isId` は画面5つが URL のIDの判定に使う）
+ * どのファイルから読んでもよい（`isId` は `app/guard.ts` が URL のIDの判定に使う）
  */
 const READ_ONLY_EXPORTS = ["isId"];
 

--- a/server/test/spec-refs.test.ts
+++ b/server/test/spec-refs.test.ts
@@ -90,9 +90,9 @@ describe("設計書が指しているコードが実在する", () => {
     },
     {
       spec: "../../docs/records/specs/2026-08-14-82-multi-editor-audit-design.md",
-      code: "../app/actions.ts",
+      code: "../app/guard.ts",
       name: "requireSession",
-      decl: "async function requireSession(",
+      decl: "export async function requireSession(",
       section: "監査ログの設計書 §4",
     },
     {


### PR DESCRIPTION
Closes #140

## 何をしたか

9枚の画面が同じ4行（`getSession` → 無ければ `redirect("/signin")`）を、4枚が同じ5行（`Number` → `isId` → `notFound`）を書き写していた。これを `server/app/guard.ts` に寄せた。

| 指標 | 前 | 後 |
|---|---|---|
| `getSession` を自分で呼ぶ `page.tsx` | 10枚 | 1枚（`app/signin/page.tsx` だけ） |
| `isId` を直に書く `page.tsx` | 4枚 | 0枚 |
| テスト件数 | 373 | 373 |

`app/signin/page.tsx` は寄せない。あの画面は「サインイン**済み**なら追い返す」という逆の判定で、行き先も違う。

**書き写す形が危ないのは、画面を1枚足したときに書き忘れてもエラーにならない**こと。サインインしていない人に中身が見える画面が、黙って1枚増える。

## スコープを広げた点

`app/actions.ts` の `requireSession` も同じ場所へ移した。中身が画面のものと1文字も違わなかったため。移さずに2つ目を作ると、重複を減らすつもりで増やすことになる。

**管理者の判定だけは分けたまま残した。** 画面は `redirect` で追い返してよいが、Server Action は `redirect` にすると拒否と成功が同じ `NEXT_REDIRECT` になって見分けられなくなる（入力者を3人にする設計書 §4 の実測）。

### この移動を `spec-refs.test.ts` が捕まえた

```
AssertionError: ../app/actions.ts に async function requireSession( が無い: expected false to be true
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
```

設計書がコードを指す先を保つための検査（Issue #96 で入れたもの）が、まさにそのとおりに働いた。設計書（監査ログ §4）と検査表の両方を新しい場所に合わせて緑に戻した。

あわせて、移動で嘘になる注記を3つ直した。

| 場所 | 直した内容 |
|---|---|
| 監査ログ 設計書 §4 | 「`requireUserId()` の隣に管理者を確かめる関数を置き」→ もう隣ではない。置き場所を名指しした |
| `write-boundary.test.ts` | 「`isId` は画面5つが使う」→ 今は `app/guard.ts` だけ |
| `src/admin.ts` | 「監査ログの画面も同じ判定が要る」→ 今は `app/guard.ts` が読む |

## 壊して赤くなることの確認

いずれも `app/guard.ts` を壊して `test/pages.test.ts` を流した。

| 壊した箇所 | 赤くなった本数 |
|---|---|
| `requireSession` の `redirect("/signin")` を外す | 9件 |
| `requireId` の `isId` 判定を外す | 5件 |
| `requireAdminSession` の `isAdmin` 判定を外す | 1件（`app/audit/page.test.ts`「管理者ではない入力者は追い返される」） |

**画面ごとの差は消えていない。** `/audit` を未サインインで開くと `/signin`、非管理者で開くと `/` へ行く。この2つを別々のテストが見ていることを、上の変異1と変異3が別々のテストを赤くすることで確かめた。複合主キーの画面が2つのIDを別々に判定していることも、変異2で「数でないテーマID」と「数でない銘柄ID」が両方赤くなることで確かめた。

## レイアウトにしない理由

`app/(admin)/layout.tsx` は管理画面を分ける設計書 §3 が実測で棄却済み。画面のテストは `renderToStaticMarkup(await Page())` で描いており（`test/render-page.ts` の `render`）、レイアウトは Next.js のルーターが合成するためこの呼び方では一度も描かれない。判定がテストの届かない場所へ移る。画面が自分で呼ぶ関数なら、今のテストがそのまま判定を見られる。

## 副産物: `node_modules/` が `.gitignore` から漏れていた

最初のコミットに `node_modules/.vite/vitest/*/results.json`（変異テストで赤くしたときの記録）が紛れ込んでいた。最上位の `.gitignore` に `node_modules/` が無く、`server/.gitignore` の記述では最上位を覆えないため。取り除き、最上位にも書いた。

## 効果（正直な数字）

**行数は増えた。**

| 内訳 | 行数 |
|---|---|
| `app/guard.ts` を除く15ファイル | −84 |
| `app/guard.ts`（新規） | +88 |
| **差引** | **+4** |

減らすための変更ではなく、**画面を1枚足したときに判定を書き忘れる余地を消すための変更**である。

## 品質ゲート

```
$ pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint
Test Files  30 passed (30)
     Tests  373 passed (373)
Checked 97 files in 83ms. No fixes applied.
```

この Worktree は `TEST_DATABASE_URL` を `ichikabu_test_140` に向けてある（`.env.local` はコミット対象外）。

## 別Issueに切ったもの

**#147** — サインインしていない状態で Server Action を叩いたときの検査が1本も無い。`requireSession` を壊しても赤くなるのは画面の9件だけで、`app/actions.test.ts` は1件も落ちない。この変更より前からの穴だが、画面と Server Action が同じ関数を通るようになったぶん「画面のテストが守っているから Server Action も守られている」と読み違える余地が新しくできたため起票した。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PnUjseR21HBWSE9siKbKj
