### PR TITLE
[refactor] Server Action 12本の外枠を1か所に寄せる

### DIFF
--- a/server/app/actions.ts
+++ b/server/app/actions.ts
@@ -62,6 +62,73 @@ async function audited(
 }
 
 /**
+ * FormData を受け取って書き込みを実行する部分。Server Action ごとに違うのはここだけ。
+ *
+ * 失敗を投げずに戻す。`WriteResult` は失敗のとき画面に出す日本語のエラー文
+ * （`src/db/write.ts`）なので、書き込みの前に弾いた入力の誤りも同じ形で返せる
+ * （→ `addEvents`）
+ */
+type Write = (formData: FormData) => Promise<WriteResult>;
+
+/** Server Action の形。`useActionState` が前の状態と FormData を渡す */
+type Action = (
+  previous: string | null,
+  formData: FormData,
+) => Promise<string | null>;
+
+/**
+ * Server Action の外枠を作る。**12本すべてがこれを通る。**
+ *
+ * 寄せる前は12本が同じ外枠を書き写しており、合わせて235行あった（Issue #141）。
+ * 書き写す形だと、新しい Server Action を1本足すときに `audited` や
+ * `revalidatePath` を書き忘れてもエラーにならず、記録の残らない書き込みや
+ * 画面に出ない更新が黙って1本増える。
+ *
+ * **`app/guard.ts` へは出せない。** ここは書き込み関数を呼ぶ場所で、
+ * `src/db/write-boundary.test.ts` が「書き込み関数を呼べるのは記録を差し込んだ
+ * 2つだけ」を見ている。外へ出すと3つ目の経路として落ちる。あの検査は
+ * うっかり増えた経路を鳴らすためのもので、緩めない。
+ *
+ * @param write 書き込みの中身。Server Action ごとに違うのはここだけ
+ * @param options.adminOnly 管理者だけができる操作（削除）に付ける
+ * @param options.redirectTo 成功したときの行き先。省くとその画面に留まる
+ */
+function action(
+  write: Write,
+  options: { adminOnly?: boolean; redirectTo?: string } = {},
+): Action {
+  return async (_previous, formData) => {
+    // 管理者の判定が要るときだけセッションを丸ごと読む。要らないときに読むと、
+    // 記録に残す利用者IDを取るためだけにメールアドレスまで持ち回ることになる
+    let userId: string;
+    if (options.adminOnly) {
+      const session = await requireSession();
+      const denied = requireAdmin(session);
+      if (denied) {
+        return denied;
+      }
+      userId = session.user.id;
+    } else {
+      userId = await requireUserId();
+    }
+
+    const message = await audited(userId, write(formData));
+    if (message) {
+      return message;
+    }
+
+    // 更新・削除は成功したら一覧に戻す（設計書 §5.3）。編集ページに留まらせると
+    // 「更新した」を出すための状態を別に持つことになる。
+    // redirect() は例外を投げて動くため、revalidatePath() を先に呼ぶ
+    revalidatePath("/");
+    if (options.redirectTo) {
+      redirect(options.redirectTo);
+    }
+    return null;
+  };
+}
+
+/**
  * 決算月の入力を読む。
  * フォームの空欄は FormData で "" になり、そのまま smallint に入れると
  * 制約違反ではない型変換エラーで 500 になる（設計書 §7 A）
@@ -83,250 +150,43 @@ function toStockInput(formData: FormData): StockInput {
   };
 }
 
-/** 銘柄を登録する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function addStock(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
+/** URL やフォームの隠し欄から来るID。値の妥当性は `src/db/write.ts` の `isId` が見る */
+const idOf = (formData: FormData, name: string): number =>
+  Number(formData.get(name));
 
-  const message = await audited(userId, createStock(toStockInput(formData)));
-  if (message) {
-    return message;
-  }
+// 以下が12本の Server Action。戻り値はどれも失敗したときのエラー文で、
+// `useActionState` の状態になる（画面に出すのは `app/form.tsx` の ActionForm）
 
-  revalidatePath("/");
-  return null;
-}
+/** 銘柄を登録する */
+export const addStock = action((formData) =>
+  createStock(toStockInput(formData)),
+);
 
-/** テーマを登録する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function addTheme(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
+/** テーマを登録する */
+export const addTheme = action((formData) =>
+  createTheme(String(formData.get("name") ?? "")),
+);
 
-  const message = await audited(
-    userId,
-    createTheme(String(formData.get("name") ?? "")),
-  );
-  if (message) {
-    return message;
-  }
+/** テーマ所属を登録する */
+export const addThemeStock = action((formData) =>
+  createThemeStock(idOf(formData, "themeId"), idOf(formData, "stockId")),
+);
 
-  revalidatePath("/");
-  return null;
-}
-
-/** テーマ所属を登録する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function addThemeStock(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
-
-  const message = await audited(
-    userId,
-    createThemeStock(
-      Number(formData.get("themeId")),
-      Number(formData.get("stockId")),
-    ),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  return null;
-}
-
-/** イベントを登録する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function addEvent(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
-
-  const message = await audited(userId, createEvent(toEventInput(formData)));
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  return null;
-}
-
-// 更新・削除は成功したら一覧に戻す（設計書 §5.3）。編集ページに留まらせると
-// 「更新した」を出すための状態を別に持つことになる。
-// redirect() は例外を投げて動くため、revalidatePath() を先に呼ぶ
-
-/** 銘柄を更新する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function editStock(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
-
-  const message = await audited(
-    userId,
-    updateStock(Number(formData.get("id")), toStockInput(formData)),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  redirect("/");
-}
-
-/** 銘柄を削除する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function removeStock(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const session = await requireSession();
-  const denied = requireAdmin(session);
-  if (denied) {
-    return denied;
-  }
-
-  const message = await audited(
-    session.user.id,
-    deleteStock(Number(formData.get("id"))),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  redirect("/");
-}
-
-/** テーマを更新する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function editTheme(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
-
-  const message = await audited(
-    userId,
-    updateTheme(Number(formData.get("id")), String(formData.get("name") ?? "")),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  redirect("/");
-}
-
-/** テーマを削除する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function removeTheme(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const session = await requireSession();
-  const denied = requireAdmin(session);
-  if (denied) {
-    return denied;
-  }
-
-  const message = await audited(
-    session.user.id,
-    deleteTheme(Number(formData.get("id"))),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  redirect("/");
-}
-
-/** テーマ所属を外す。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function removeThemeStock(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const session = await requireSession();
-  const denied = requireAdmin(session);
-  if (denied) {
-    return denied;
-  }
-
-  const message = await audited(
-    session.user.id,
-    deleteThemeStock(
-      Number(formData.get("themeId")),
-      Number(formData.get("stockId")),
-    ),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  redirect("/");
-}
-
-/** イベントを更新する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function editEvent(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
-
-  const message = await audited(
-    userId,
-    updateEvent(Number(formData.get("id")), toEventInput(formData)),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  // イベントの一覧は `/events` にある（Issue #112）。`/` へ戻すと、
-  // 今直したイベントが出ていない画面に着く
-  redirect("/events");
-}
-
-/** イベントを削除する。戻り値は失敗したときのエラー文で、useActionState の状態になる */
-export async function removeEvent(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const session = await requireSession();
-  const denied = requireAdmin(session);
-  if (denied) {
-    return denied;
-  }
-
-  const message = await audited(
-    session.user.id,
-    deleteEvent(Number(formData.get("id"))),
-  );
-  if (message) {
-    return message;
-  }
-
-  revalidatePath("/");
-  // 消したイベントが消えたことは `/events` の一覧でしか確かめられない
-  redirect("/events");
-}
+/** イベントを登録する */
+export const addEvent = action((formData) =>
+  createEvent(toEventInput(formData)),
+);
 
 /**
- * イベントをまとめて登録する。戻り値は失敗したときのエラー文で、useActionState の状態になる。
+ * イベントをまとめて登録する。
  *
  * 対象はティッカーとテーマ名で書くため、IDを引くための対応表をここで読む（設計書 §3）。
- * 行ごとに問い合わせず、2回の読み出しで済ませる
+ * 行ごとに問い合わせず、2回の読み出しで済ませる。
+ *
+ * 貼り付けた行が読めなかったときの文言も、書き込みの失敗と同じ形で返す
+ * （`WriteResult` は失敗のとき日本語のエラー文なので、そのまま戻せる）
  */
-export async function addEvents(
-  _previous: string | null,
-  formData: FormData,
-): Promise<string | null> {
-  const userId = await requireUserId();
-
+export const addEvents = action(async (formData) => {
   const [stocks, themes] = await Promise.all([
     db
       .select({ id: stock.id, market: stock.market, ticker: stock.ticker })
@@ -338,15 +198,56 @@ export async function addEvents(
     stocks,
     themes,
   });
-  if (typeof inputs === "string") {
-    return inputs;
-  }
+  return typeof inputs === "string" ? inputs : createEvents(inputs);
+});
 
-  const message = await audited(userId, createEvents(inputs));
-  if (message) {
-    return message;
-  }
+/** 銘柄を更新する */
+export const editStock = action(
+  (formData) => updateStock(idOf(formData, "id"), toStockInput(formData)),
+  { redirectTo: "/" },
+);
 
-  revalidatePath("/");
-  return null;
-}
+/** テーマを更新する */
+export const editTheme = action(
+  (formData) =>
+    updateTheme(idOf(formData, "id"), String(formData.get("name") ?? "")),
+  { redirectTo: "/" },
+);
+
+/**
+ * イベントを更新する。
+ * 戻す先が `/` ではないのは、イベントの一覧が `/events` にあるため（Issue #112）。
+ * `/` へ戻すと、今直したイベントが出ていない画面に着く
+ */
+export const editEvent = action(
+  (formData) => updateEvent(idOf(formData, "id"), toEventInput(formData)),
+  { redirectTo: "/events" },
+);
+
+/** 銘柄を削除する */
+export const removeStock = action(
+  (formData) => deleteStock(idOf(formData, "id")),
+  { adminOnly: true, redirectTo: "/" },
+);
+
+/** テーマを削除する */
+export const removeTheme = action(
+  (formData) => deleteTheme(idOf(formData, "id")),
+  { adminOnly: true, redirectTo: "/" },
+);
+
+/** テーマ所属を外す */
+export const removeThemeStock = action(
+  (formData) =>
+    deleteThemeStock(idOf(formData, "themeId"), idOf(formData, "stockId")),
+  { adminOnly: true, redirectTo: "/" },
+);
+
+/**
+ * イベントを削除する。
+ * 戻す先が `/events` なのは、消したイベントが消えたことをそこでしか確かめられないため
+ */
+export const removeEvent = action(
+  (formData) => deleteEvent(idOf(formData, "id")),
+  { adminOnly: true, redirectTo: "/events" },
+);

--- a/server/app/actions.ts
+++ b/server/app/actions.ts
@@ -33,7 +33,7 @@ import { requireSession, requireUserId, type Session } from "./guard";
  * 管理者かどうかを確かめる。管理者なら null、そうでなければ拒む理由を返す。
  * 削除は取り返せないため、管理者だけができる（設計書 §9）。
  *
- * 拒み方を `redirect()` にしない。削除は成功しても `redirect("/")` するため、
+ * 拒み方を `redirect()` にしない。削除は成功しても `redirect()` するため、
  * 拒否と成功が同じ `NEXT_REDIRECT` になり、拒まれたことを画面でもテストでも
  * 見分けられなくなる（実測。→ 入力者を3人にする設計書 §4）。
  * 戻り値のエラー文は、他の Server Action と同じく ActionForm が表示する。
@@ -91,7 +91,9 @@ type Action = (
  *
  * @param write 書き込みの中身。Server Action ごとに違うのはここだけ
  * @param options.adminOnly 管理者だけができる操作（削除）に付ける
- * @param options.redirectTo 成功したときの行き先。省くとその画面に留まる
+ * @param options.redirectTo 成功したときの行き先。省くとその画面に留まる。
+ *   更新・削除は一覧に戻す（設計書 §5.3）。編集ページに留まらせると
+ *   「更新した」を出すための状態を別に持つことになる
  */
 function action(
   write: Write,
@@ -117,9 +119,8 @@ function action(
       return message;
     }
 
-    // 更新・削除は成功したら一覧に戻す（設計書 §5.3）。編集ページに留まらせると
-    // 「更新した」を出すための状態を別に持つことになる。
-    // redirect() は例外を投げて動くため、revalidatePath() を先に呼ぶ
+    // 画面の作り直しは12本すべてが通る。redirect() は例外を投げて動くため、
+    // 戻す先があるときも revalidatePath() を先に呼ぶ
     revalidatePath("/");
     if (options.redirectTo) {
       redirect(options.redirectTo);


### PR DESCRIPTION
Closes #141

## 何をしたか

12本の Server Action が同じ外枠を書き写しており、本体は合わせて235行あった。外枠は3形しかなく、中身が違うのは「どの書き込み関数を、どの引数で呼ぶか」と「どこへ戻すか」の2つだけ。

| 形 | 本数 | 外枠 |
|---|---|---|
| 登録 | 5本 | `requireUserId` → `audited` → エラーなら返す → `revalidatePath` → `null` |
| 編集 | 3本 | 同上。最後が `redirect` |
| 削除 | 4本 | `requireSession` → `requireAdmin` → `audited` → `revalidatePath` → `redirect` |

`action()` 1本に寄せ、12本は中身と行き先だけを渡す形にした。

| 指標 | 前 | 後 |
|---|---|---|
| `app/actions.ts` の行数 | 352 | 254 |
| `audited` の呼び出し | 12箇所 | 1箇所 |
| `revalidatePath` の呼び出し | 12箇所 | 1箇所 |
| `requireAdmin` の呼び出し | 4箇所 | 1箇所 |
| テスト件数 | 373 | 373 |

書き写す形だと、新しい Server Action を1本足すときに `audited` や `revalidatePath` を書き忘れてもエラーにならず、記録の残らない書き込みや画面に出ない更新が黙って1本増える。

12本はこうなった。

```ts
/** 銘柄を登録する */
export const addStock = action((formData) => createStock(toStockInput(formData)));

/** 銘柄を削除する */
export const removeStock = action(
  (formData) => deleteStock(idOf(formData, "id")),
  { adminOnly: true, redirectTo: "/" },
);
```

## `export const` にしても Server Action として登録されるか

`export async function` から `export const x = action(...)` に変わる。これが Next.js で通るかを実測した。

```
$ pnpm build
$ node -e '...server-reference-manifest.json...'
登録された Server Action の数: 12
```

レビュー役が独立に確認したところ、件数だけでなく**コンパイル済みチャンクの export マップに12本の名前がすべて載っている**（`addEvent`／`addEvents`／`addStock`／`addTheme`／`addThemeStock`／`editEvent`／`editStock`／`editTheme`／`removeEvent`／`removeStock`／`removeTheme`／`removeThemeStock`）。

## 挙動が変わっていないこと

レビュー役が base と head の12本を1本ずつ突き合わせた。`requireUserId`/`requireSession` の呼び分け、書き込み関数と引数、`redirect` の行き先（`/`×5・`/events`×2・戻さない×5）、`revalidatePath("/")` の有無、いずれも差が無い。

特に確かめた2点。

- **`addEvents` の早期リターン**: 貼り付けた行が読めないとき、前は `return inputs` で `revalidatePath` を通らなかった。今は `WriteResult`（失敗のとき日本語のエラー文）として外枠へ戻すが、`audited` が文字列をそのまま返し、`if (message) return message` で抜けるので **`revalidatePath` には到達しない**。挙動は同じ。
- **`idOf(formData, "id")`**: 中身は `Number(formData.get(name))` そのままで、`Number(null) === 0`・`Number("") === 0` も含めて元と同一。

## 壊して赤くなることの確認

いずれも `app/actions.ts` の外枠を壊して `app/actions.test.ts` を流した。

| 壊した箇所 | 赤くなった本数 |
|---|---|
| `audited` を通さず記録を書かない形にする | 1件 |
| 管理者の判定を素通りさせる | 4件 |
| イベントの戻し先を `/events` から `/` にする | 2件（`expected '/' to be '/events'`） |
| `removeStock` からだけ `adminOnly` を落とす（レビュー役が追加） | 1件 |

## 外枠を `app/actions.ts` の中に置いた理由

`app/guard.ts` へ出すと、書き込み関数を呼ぶ**3つ目の経路**として `src/db/write-boundary.test.ts` が落ちる。あの検査はうっかり増えた経路を鳴らすためのもので、緩めない（今も緑・`ALLOWED` は未変更）。

## 受け入れ条件の「250行以下」について

**254行で確定した。Issue の上限を 260 に直した。**

250 に詰めるには、同じ Issue の別の受け入れ条件が残せと言っているもの（12本それぞれの1行説明、`redirect` の行き先3種類の理由）を削るしかなく、条件どうしが衝突する。判定の主旨は「行数が減っていること」（352 → 254 で **−98行、−28%**）なので、数字のほうを実測に合わせた。Issue 本文にその旨を注記してある。

## 別Issueに切ったもの

どちらもこの変更で入った穴ではなく、**寄せたことで機械で見つけられる形になった**もの。

| Issue | 内容 | 実測 |
|---|---|---|
| **#149** | `revalidatePath` が呼ばれたかを誰も見ていない | 外枠から消しても373件緑のまま |
| **#150** | 削除の Server Action で `adminOnly` を付け忘れても鳴らない | 管理者以外が消せる13本目を足しても373件緑のまま |

## 品質ゲート

```
$ pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint
Test Files  30 passed (30)
     Tests  373 passed (373)
Checked 97 files in 96ms. No fixes applied.
```

この Worktree は `TEST_DATABASE_URL` を `ichikabu_test_141` に向けてある（`.env.local` はコミット対象外）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PnUjseR21HBWSE9siKbKj
