### PR TITLE
[refactor] signInAs が requestHeaders を自分で設定する形にする

### DIFF
--- a/server/app/actions.test.ts
+++ b/server/app/actions.test.ts
@@ -1,6 +1,5 @@
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { auth } from "../src/auth";
 import { db } from "../src/db";
 import {
   auditLog,
@@ -19,8 +18,7 @@ import {
 } from "../src/db/write";
 import { resetDatabase } from "../test/helpers";
 import { eventInput, stockInput } from "../test/inputs";
-import { redirectedTo } from "../test/render-page";
-import { requestHeaders } from "../test/setup";
+import { PASSWORD, redirectedTo, signInAs } from "../test/render-page";
 import {
   addEvent,
   editEvent,
@@ -42,24 +40,6 @@ vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
 // （seedUser が小文字にして入れるため、大文字違いで同じ人になる）
 const ADMIN = "admin@example.com";
 const EDITOR = "editor@example.com";
-const PASSWORD = "correct-horse-battery-staple";
-
-/** サインインして、以降の Server Action がそのセッションで動くようにする */
-async function signInAs(email: string): Promise<void> {
-  const res = await auth.handler(
-    new Request("http://localhost:3000/api/auth/sign-in/email", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ email, password: PASSWORD }),
-    }),
-  );
-  const cookie = res.headers.get("set-cookie");
-  if (!cookie) {
-    throw new Error(`サインインできなかった: ${email}`);
-  }
-  // `;` の前が「名前=値」で、後ろは有効期限などの属性
-  requestHeaders.current = new Headers({ cookie: cookie.split(";")[0] });
-}
 
 function form(values: Record<string, string>): FormData {
   const formData = new FormData();

--- a/server/app/audit/page.test.ts
+++ b/server/app/audit/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../src/auth";
 import { record } from "../../src/db/audit";
 import { seedUser } from "../../src/db/seed-user";
 import { createStock, createTheme } from "../../src/db/write";
@@ -11,7 +10,6 @@ import {
   render,
   signInAs,
 } from "../../test/render-page";
-import { requestHeaders } from "../../test/setup";
 import Page from "./page";
 
 // この画面は管理者だけが開ける。管理者のメールアドレスは `test/setup.ts` が
@@ -19,11 +17,6 @@ import Page from "./page";
 // （`seedUser` が小文字にして入れるため、大文字違いで同じ人になる）
 const ADMIN = "admin@example.com";
 const EDITOR = "editor@example.com";
-
-/** サインインして、以降の描画がそのセッションで動くようにする */
-async function signIn(email: string): Promise<void> {
-  requestHeaders.current = await signInAs(auth.handler, email);
-}
 
 /** 各テストの前に作り直す利用者のID。記録に残す人の出どころ */
 const userIds = { admin: "", editor: "" };
@@ -40,13 +33,13 @@ describe("監査ログの画面", () => {
   it("管理者ではない入力者は追い返される", async () => {
     // 入力者に監査ログは見せない（入力者を3人にする設計書 §2）。
     // 画面から入口を消すだけでは、URL を直に打つ経路が塞がったか判定できない
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     expect(await redirectedTo(Page)).toBe("/");
   });
 
   it("記録が0件のとき、その旨が出る", async () => {
-    await signIn(ADMIN);
+    await signInAs(ADMIN);
 
     expect(await render(Page)).toContain("記録なし");
   });
@@ -54,7 +47,7 @@ describe("監査ログの画面", () => {
   it("管理者には日時・操作した人・種別・対象が新しい順に出る", async () => {
     await record(userIds.admin, entriesOf(await createTheme("半導体")));
     await record(userIds.admin, entriesOf(await createStock(stockInput())));
-    await signIn(ADMIN);
+    await signInAs(ADMIN);
 
     const html = await render(Page);
     expect(html).toContain(ADMIN);
@@ -69,7 +62,7 @@ describe("監査ログの画面", () => {
 
   it("取り込みが入れた記録は操作した人が「取り込み」と出る", async () => {
     await record(null, entriesOf(await createTheme("半導体")));
-    await signIn(ADMIN);
+    await signInAs(ADMIN);
 
     expect(await render(Page)).toContain("取り込み");
   });

--- a/server/app/contributions/page.test.ts
+++ b/server/app/contributions/page.test.ts
@@ -1,20 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../src/auth";
 import { record } from "../../src/db/audit";
 import { seedUser } from "../../src/db/seed-user";
 import { createTheme, deleteTheme, updateTheme } from "../../src/db/write";
 import { entriesOf, resetDatabase } from "../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
-import { requestHeaders } from "../../test/setup";
 import Page from "./page";
 
 const ALICE = "alice@example.com";
 const BOB = "bob@example.com";
-
-/** サインインして、以降の描画がそのセッションで動くようにする */
-async function signIn(email: string): Promise<void> {
-  requestHeaders.current = await signInAs(auth.handler, email);
-}
 
 /** 各テストの前に作り直す利用者のID。記録に残す人の出どころ */
 const userIds = { alice: "", bob: "" };
@@ -28,7 +21,7 @@ beforeEach(async () => {
 // 追い返しは `test/pages.test.ts` の表が全画面ぶん見ている
 describe("貢献度の画面", () => {
   it("記録が0件のとき、その旨が出る", async () => {
-    await signIn(ALICE);
+    await signInAs(ALICE);
 
     expect(await render(Page)).toContain("記録なし");
   });
@@ -40,7 +33,7 @@ describe("貢献度の画面", () => {
       entriesOf(await updateTheme(1, "半導体・製造装置")),
     );
     await record(userIds.alice, entriesOf(await deleteTheme(1)));
-    await signIn(ALICE);
+    await signInAs(ALICE);
 
     const html = await render(Page);
     expect(html).toContain(ALICE);
@@ -53,7 +46,7 @@ describe("貢献度の画面", () => {
     await record(userIds.alice, entriesOf(await createTheme("半導体")));
     await record(userIds.bob, entriesOf(await createTheme("防衛")));
     await record(userIds.bob, entriesOf(await createTheme("造船")));
-    await signIn(ALICE);
+    await signInAs(ALICE);
 
     const html = await render(Page);
     // 先に両方が出ていることを確かめる。片方が出ていないと indexOf が -1 になり、
@@ -65,7 +58,7 @@ describe("貢献度の画面", () => {
 
   it("取り込みが入れた記録は「取り込み」として数えられる", async () => {
     await record(null, entriesOf(await createTheme("半導体")));
-    await signIn(ALICE);
+    await signInAs(ALICE);
 
     const html = await render(Page);
     expect(html).toContain("取り込み");
@@ -75,7 +68,7 @@ describe("貢献度の画面", () => {
   it("入力者ごとに分かれて数えられる", async () => {
     await record(userIds.alice, entriesOf(await createTheme("半導体")));
     await record(userIds.bob, entriesOf(await createTheme("防衛")));
-    await signIn(ALICE);
+    await signInAs(ALICE);
 
     // まとめて数えると「登録 2件」の1行になる。人数もそこで狂う
     expect(await render(Page)).toContain("（2人）");
@@ -84,7 +77,7 @@ describe("貢献度の画面", () => {
   it("取り込みは人数に数えない", async () => {
     await record(userIds.alice, entriesOf(await createTheme("半導体")));
     await record(null, entriesOf(await createTheme("防衛")));
-    await signIn(ALICE);
+    await signInAs(ALICE);
 
     // 行は2つ出るが、人は1人。取り込みを人数に混ぜると「2人」になる
     expect(await render(Page)).toContain("（1人）");

--- a/server/app/events/[id]/page.test.ts
+++ b/server/app/events/[id]/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../../src/auth";
 import { seedUser } from "../../../src/db/seed-user";
 import {
   createEvent,
@@ -11,7 +10,6 @@ import { htmlOf } from "../../../test/dom";
 import { idOf, resetDatabase } from "../../../test/helpers";
 import { eventInput, stockInput } from "../../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
-import { requestHeaders } from "../../../test/setup";
 import Page from "./page";
 
 const EDITOR = "editor@example.com";
@@ -20,7 +18,7 @@ const EDITOR = "editor@example.com";
 beforeEach(async () => {
   await resetDatabase();
   await seedUser(EDITOR, PASSWORD);
-  requestHeaders.current = await signInAs(auth.handler, EDITOR);
+  await signInAs(EDITOR);
 });
 
 /** 空にできる欄をすべて空にしたイベント。埋めたい欄だけ上書きする */

--- a/server/app/events/page.test.ts
+++ b/server/app/events/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../src/auth";
 import { record } from "../../src/db/audit";
 import { seedUser } from "../../src/db/seed-user";
 import {
@@ -12,7 +11,6 @@ import { htmlOf } from "../../test/dom";
 import { entriesOf, resetDatabase } from "../../test/helpers";
 import { eventInput } from "../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
-import { requestHeaders } from "../../test/setup";
 import Page from "./page";
 
 const ADMIN = "admin@example.com";
@@ -38,11 +36,6 @@ async function addEvent(shortLabel: string, startDate?: string) {
 /** 銘柄を1件作る */
 async function addStock(ticker: string, name: string) {
   return createStock({ market: "JP", ticker, name, fiscalMonth: 3 });
-}
-
-/** サインインして、以降の描画がそのセッションで動くようにする */
-async function signIn(email: string): Promise<void> {
-  requestHeaders.current = await signInAs(auth.handler, email);
 }
 
 /** 各テストの前に作り直す利用者のID。記録に残す人の出どころ */
@@ -72,7 +65,7 @@ describe("イベントの画面", () => {
     ]) {
       await addEvent(shortLabel, startDate);
     }
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     const html = await render(Page);
 
@@ -91,7 +84,7 @@ describe("イベントの画面", () => {
     await createTheme("半導体");
     await addStock("7203", "トヨタ自動車");
     await addStock("6758", "ソニーグループ");
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     const html = await render(Page);
 
@@ -109,7 +102,7 @@ describe("イベントの画面", () => {
 
   it("入れた人が名前で出る", async () => {
     await record(userIds.editor, entriesOf(await addEvent("CPI")));
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     expect(await render(Page)).toContain(EDITOR);
   });
@@ -117,7 +110,7 @@ describe("イベントの画面", () => {
   it("取り込みが入れたイベントは「取り込み」と出る", async () => {
     // 取り込みスクリプトは記録を残すが、操作した人は NULL になる
     await record(null, entriesOf(await addEvent("CPI")));
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     const html = await render(Page);
     expect(html).toContain("取り込み");
@@ -129,7 +122,7 @@ describe("イベントの画面", () => {
     // 記録を書かない）。取り込みが入れたことにすると、取り込みがやっていない
     // 登録を取り込みの手柄にする
     await addEvent("CPI");
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     const html = await render(Page);
     expect(html).toContain("記録なし");
@@ -162,7 +155,7 @@ describe("イベントの画面", () => {
         }),
       ),
     );
-    await signIn(EDITOR);
+    await signInAs(EDITOR);
 
     const html = await render(Page);
     expect(html).toContain("記録なし");

--- a/server/app/page.test.ts
+++ b/server/app/page.test.ts
@@ -1,11 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../src/auth";
 import { seedUser } from "../src/db/seed-user";
 import { createStock, createTheme, createThemeStock } from "../src/db/write";
 import { htmlOf } from "../test/dom";
 import { entriesOf, resetDatabase } from "../test/helpers";
 import { PASSWORD, render, signInAs } from "../test/render-page";
-import { requestHeaders } from "../test/setup";
 import Page from "./page";
 
 const EDITOR = "editor@example.com";
@@ -29,7 +27,7 @@ async function addTheme(name: string): Promise<string> {
 beforeEach(async () => {
   await resetDatabase();
   await seedUser(EDITOR, PASSWORD);
-  requestHeaders.current = await signInAs(auth.handler, EDITOR);
+  await signInAs(EDITOR);
 });
 
 describe("銘柄とテーマの画面", () => {

--- a/server/app/signin/page.test.ts
+++ b/server/app/signin/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../src/auth";
 import { seedUser } from "../../src/db/seed-user";
 import { resetDatabase } from "../../test/helpers";
 import {
@@ -26,7 +25,7 @@ beforeEach(async () => {
 
 describe("サインインの画面", () => {
   it("サインイン済みで開くと管理画面へ戻される", async () => {
-    requestHeaders.current = await signInAs(auth.handler, EDITOR);
+    await signInAs(EDITOR);
 
     expect(await redirectedTo(open())).toBe("/");
   });

--- a/server/app/status/page.test.ts
+++ b/server/app/status/page.test.ts
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../src/auth";
 import { seedUser } from "../../src/db/seed-user";
 import { createStock } from "../../src/db/write";
 import { GAP_KINDS, GAP_TITLES } from "../../src/status";
 import { entriesOf, resetDatabase } from "../../test/helpers";
 import { stockInput } from "../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../test/render-page";
-import { requestHeaders } from "../../test/setup";
 import Page from "./page";
 
 const EDITOR = "editor@example.com";
@@ -14,7 +12,7 @@ const EDITOR = "editor@example.com";
 beforeEach(async () => {
   await resetDatabase();
   await seedUser(EDITOR, PASSWORD);
-  requestHeaders.current = await signInAs(auth.handler, EDITOR);
+  await signInAs(EDITOR);
 });
 
 describe("状態の画面", () => {

--- a/server/app/stocks/[id]/page.test.ts
+++ b/server/app/stocks/[id]/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../../src/auth";
 import { seedUser } from "../../../src/db/seed-user";
 import {
   createStock,
@@ -9,7 +8,6 @@ import {
 import { htmlOf } from "../../../test/dom";
 import { entriesOf, idOf, resetDatabase } from "../../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
-import { requestHeaders } from "../../../test/setup";
 import Page from "./page";
 
 const EDITOR = "editor@example.com";
@@ -18,7 +16,7 @@ const EDITOR = "editor@example.com";
 beforeEach(async () => {
   await resetDatabase();
   await seedUser(EDITOR, PASSWORD);
-  requestHeaders.current = await signInAs(auth.handler, EDITOR);
+  await signInAs(EDITOR);
 });
 
 /**

--- a/server/app/themes/[id]/page.test.ts
+++ b/server/app/themes/[id]/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../../src/auth";
 import { seedUser } from "../../../src/db/seed-user";
 import {
   createStock,
@@ -9,7 +8,6 @@ import {
 import { htmlOf } from "../../../test/dom";
 import { entriesOf, idOf, resetDatabase } from "../../../test/helpers";
 import { PASSWORD, render, signInAs } from "../../../test/render-page";
-import { requestHeaders } from "../../../test/setup";
 import Page from "./page";
 
 const EDITOR = "editor@example.com";
@@ -18,7 +16,7 @@ const EDITOR = "editor@example.com";
 beforeEach(async () => {
   await resetDatabase();
   await seedUser(EDITOR, PASSWORD);
-  requestHeaders.current = await signInAs(auth.handler, EDITOR);
+  await signInAs(EDITOR);
 });
 
 /** 書き込みが失敗しても例外は飛ばないため、`idOf` で包んでその場で落とす */

--- a/server/app/themes/[id]/stocks/[stockId]/page.test.ts
+++ b/server/app/themes/[id]/stocks/[stockId]/page.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { auth } from "../../../../../src/auth";
 import { seedUser } from "../../../../../src/db/seed-user";
 import {
   createStock,
@@ -9,7 +8,6 @@ import {
 import { entriesOf, idOf, resetDatabase } from "../../../../../test/helpers";
 import { stockInput } from "../../../../../test/inputs";
 import { PASSWORD, render, signInAs } from "../../../../../test/render-page";
-import { requestHeaders } from "../../../../../test/setup";
 import Page from "./page";
 
 const EDITOR = "editor@example.com";
@@ -18,7 +16,7 @@ const EDITOR = "editor@example.com";
 beforeEach(async () => {
   await resetDatabase();
   await seedUser(EDITOR, PASSWORD);
-  requestHeaders.current = await signInAs(auth.handler, EDITOR);
+  await signInAs(EDITOR);
 });
 
 describe("テーマ所属を外す画面", () => {

--- a/server/test/pages.test.ts
+++ b/server/test/pages.test.ts
@@ -13,7 +13,6 @@ import Status from "../app/status/page";
 import StockEdit from "../app/stocks/[id]/page";
 import ThemeEdit from "../app/themes/[id]/page";
 import ThemeStockRemove from "../app/themes/[id]/stocks/[stockId]/page";
-import { auth } from "../src/auth";
 import { seedUser } from "../src/db/seed-user";
 import {
   createEvent,
@@ -36,11 +35,6 @@ import { requestHeaders } from "./setup";
 // （`seedUser` が小文字にして入れるため、大文字違いで同じ人になる）
 const ADMIN = "admin@example.com";
 const EDITOR = "editor@example.com";
-
-/** サインインして、以降の描画がそのセッションで動くようにする */
-async function signIn(email: string): Promise<void> {
-  requestHeaders.current = await signInAs(auth.handler, email);
-}
 
 async function addStock(ticker = "7203", name = "トヨタ自動車") {
   return idOf(
@@ -316,7 +310,7 @@ describe("管理画面に共通の約束", () => {
       if (signedOut) {
         requestHeaders.current = new Headers();
       } else {
-        await signIn(adminOnly ? ADMIN : EDITOR);
+        await signInAs(adminOnly ? ADMIN : EDITOR);
       }
 
       // 見出しが消えても、同じ文字列が `Nav` のリンク名に残る画面がある。
@@ -342,7 +336,7 @@ describe("管理画面に共通の約束", () => {
       // （Issue #122）。同じ画面のHTMLから両方を取り出して比べるので、
       // 片方だけ直すと落ちる。見出しの文字列そのものは上の表が押さえており、
       // そちらが空でないことも見ているので、両方が空で揃う抜け道は無い
-      await signIn(EDITOR);
+      await signInAs(EDITOR);
 
       const html = await render(open);
 
@@ -355,7 +349,7 @@ describe("管理画面に共通の約束", () => {
     // 監査ログのリンクは管理者にだけ出すため `LINKS` の外にある。
     // 上の繰り返しから漏れるので、5本目としてここで見る。
     // リンクは入力者に出さないので、リンクの側も管理者で開く
-    await signIn(ADMIN);
+    await signInAs(ADMIN);
 
     const linkSource = await render(Home);
     const destination = await render(Audit);
@@ -368,7 +362,7 @@ describe("管理画面に共通の約束", () => {
     "$dir は入力者に監査ログへの行き先を出さない",
     async ({ open }) => {
       // 開いても追い返されるリンクを見せない
-      await signIn(EDITOR);
+      await signInAs(EDITOR);
 
       expect(await render(open)).not.toContain('href="/audit"');
     },
@@ -379,7 +373,7 @@ describe("管理画面に共通の約束", () => {
     async ({ open }) => {
       // `Nav` を呼び忘れた画面と、`Nav` に別のメールアドレスを渡した画面は、
       // どちらもここで落ちる。行き先の一覧そのものは上の2件が見ている
-      await signIn(ADMIN);
+      await signInAs(ADMIN);
 
       expect(await render(open)).toContain('href="/audit"');
     },
@@ -390,7 +384,7 @@ describe("管理画面に共通の約束", () => {
     async ({ open }) => {
       // 数でないIDは integer 列に渡す前に弾く。渡すと型変換エラーで 500 になる。
       // 無いIDは、読めた行が無いまま画面を組み立てると 500 になる
-      await signIn(EDITOR);
+      await signInAs(EDITOR);
 
       await expectNotFound(() => render(open));
     },

--- a/server/test/render-page.ts
+++ b/server/test/render-page.ts
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { auth } from "../src/auth";
+import { requestHeaders } from "./setup";
 
 /** サインインの画面が受け付けるパスワード。テストの利用者はこれで作る */
 export const PASSWORD = "correct-horse-battery-staple";
@@ -8,26 +10,19 @@ export const PASSWORD = "correct-horse-battery-staple";
 type Page = () => Promise<ReactNode>;
 
 /**
- * `auth.handler` の型。呼ぶ側から受け取ることで、このファイルは `src/auth` を
- * 読み込まない。
- *
- * 元は「テストが `src/auth` を読み込む順を縛らないため」と書いてあったが、
- * その縛りは Issue #138 で `test/setup.ts` に移り、無くなった。
- * **引数を残すかどうかは別の話**として Issue #144 に切ってある
- */
-type Handler = (request: Request) => Promise<Response>;
-
-/**
- * サインインして、以降の描画に載せる Cookie の入った Headers を返す。
+ * サインインして、以降の描画と Server Action がそのセッションで動くようにする。
  *
  * セッションは差し替えず、本物の Better Auth のトークンを使う。
- * 差し替えると、画面が本当にサインインを見ているかを確かめられなくなる
+ * 差し替えると、画面が本当にサインインを見ているかを確かめられなくなる。
+ *
+ * `src/auth` は `test/setup.ts` ではなくここで読む。`test/setup.ts` は
+ * `setupFiles` として全テストより先に無条件で走るため、あちらで読むと
+ * サインインしないテスト（`test/spec-refs.test.ts` 等）まで `src/auth` の
+ * 読み込みに巻き込まれる（Issue #144 で実測。`GOOGLE_CLIENT_ID` が未設定だと
+ * 全滅した）。このファイルは呼ぶテストだけが読む
  */
-export async function signInAs(
-  handler: Handler,
-  email: string,
-): Promise<Headers> {
-  const res = await handler(
+export async function signInAs(email: string): Promise<void> {
+  const res = await auth.handler(
     new Request("http://localhost:3000/api/auth/sign-in/email", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -38,7 +33,8 @@ export async function signInAs(
   if (!cookie) {
     throw new Error(`サインインできなかった: ${email}`);
   }
-  return new Headers({ cookie: cookie.split(";")[0] });
+  // `;` の前が「名前=値」で、後ろは有効期限などの属性
+  requestHeaders.current = new Headers({ cookie: cookie.split(";")[0] });
 }
 
 /**

--- a/server/test/render-page.ts
+++ b/server/test/render-page.ts
@@ -19,7 +19,7 @@ type Page = () => Promise<ReactNode>;
  * `setupFiles` として全テストより先に無条件で走るため、あちらで読むと
  * サインインしないテスト（`test/spec-refs.test.ts` 等）まで `src/auth` の
  * 読み込みに巻き込まれる（Issue #144 で実測。`GOOGLE_CLIENT_ID` が未設定だと
- * 全滅した）。このファイルは呼ぶテストだけが読む
+ * 全滅した）。`src/auth` を読むのは、このファイルを読むテストだけになる
  */
 export async function signInAs(email: string): Promise<void> {
   const res = await auth.handler(

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -16,9 +16,9 @@ import { afterAll, vi } from "vitest";
 // 画面と Server Action は `next/headers` の `headers()` を呼ぶが、これは Next.js の
 // リクエストの中でしか動かない。テストが自分で入れた Headers を返す形に差し替える。
 //
-// セッションは差し替えない。本物の Better Auth のトークンを Cookie として
-// この Headers に載せる（`test/render-page.ts` の `signInAs`）。差し替えると、
-// 画面が本当にサインインを見ているかを確かめられなくなる
+// セッションは差し替えない。`test/render-page.ts` の `signInAs` が、この `current` を
+// 「本物の Better Auth のトークンを Cookie に持つ Headers」へ丸ごと差し替える。
+// セッションの側を差し替えると、画面が本当にサインインを見ているかを確かめられなくなる
 export const requestHeaders = { current: new Headers() };
 
 vi.mock("next/headers", () => ({


### PR DESCRIPTION
Closes #144

## 何をしたか

テストのサインインの作法を1か所に寄せた。呼ぶ側は `await signInAs(EMAIL)` だけになる。

| 指標 | 前 | 後 |
|---|---|---|
| `requestHeaders.current = await signInAs(...)` を書き写すテスト | 11本 | 0本 |
| `src/auth` を import するテスト | 12本 | 0本 |
| `signInAs` の書き写し（`app/actions.test.ts`、`PASSWORD` の定義ごと） | 1本 | 0本 |
| 中身が `await signInAs(email)` だけの素通しラッパー | 4本 | 0本 |
| テスト件数 | 373 | 373 |

正味 -64行。`signInAs` は `auth` を自分で読み、`requestHeaders.current` も自分で設定する。

## 着手時に討論して決めた2つの判断

Issue の「残る判断」を、立場を固定した2体の討論と実測で決めた。

### 判断1: `signInAs` は `test/render-page.ts` に置いたままにする

`test/setup.ts` へ移す案は退けた。あちらは `setupFiles` として全テストより先に無条件で走るため、`src/auth` を読むとサインインしないテストまで巻き込む。**実際に足して確かめた。**

```
# test/setup.ts の先頭に import { auth } from "../src/auth" を足して
$ GOOGLE_CLIENT_ID= pnpm exec vitest run test/spec-refs.test.ts
 Test Files  1 failed (1)
      Tests  no tests
 ❯ test/setup.ts:1:1  Error: GOOGLE_CLIENT_ID と GOOGLE_CLIENT_SECRET が設定されていない

# test/render-page.ts の先頭に同じ import を足して
$ GOOGLE_CLIENT_ID= pnpm exec vitest run test/spec-refs.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

`.gitignore` 対象の `.env.local` を手で埋める Worktree の初回準備で通る道なので、これは机上の話ではない。

**棄却した回避策**: `signInAs` の中で `await import("../src/auth")` と遅らせる案。実コード中の `await import(` は現在0件（grep に当たる3件はすべて `test/setup.ts` のコメント内）で、PR #145 が 63 → 0 にしたもの。1件戻す価値は無いと判断した。

### 判断2: サインインしていない状態を作る3か所は helper にしない

`app/signin/page.test.ts:23`・`test/pages.test.ts:300,311` の `requestHeaders.current = new Headers();` はそのまま残した。`clearCookie()` を実際に当てて測った。

```
$ git diff --shortstat
 3 files changed, 10 insertions(+), 5 deletions(-)
```

正味 +5行で、helper 案の側が自ら置いた撤退条件（+3行を超えたら負け）を超えた。ほかに2点。

- `signInAs` は非同期でこちらは同期。`await signInAs(X)` と `clearCookie()` が並ぶと不揃いになる
- `test/pages.test.ts:300` は「サインインしていないと追い返される」の**仕込みそのもの**で、helper に包むと検査対象が呼び出し名の裏に隠れる

この2本だけ `requestHeaders` の import が残る。サインインの作法（`signInAs` を呼ぶ）からは外れる側なので、Issue のゴールとは両立する。

## 壊して赤くなることの確認

| 壊した箇所 | 結果 |
|---|---|
| `signInAs` から `requestHeaders.current` への設定を消す | 12ファイル **85件赤** |
| `signInAs` が引数の email を無視して常に EDITOR にする | 4ファイル **21件赤** |
| `app/actions.ts:45` の `requireAdmin` を素通しにする | `app/actions.test.ts` **4件赤** |

3つ目は、`app/actions.test.ts` を自前の写しから共有の `signInAs` に載せ替えた後も、`ADMIN` と `EDITOR` の出し分けが効いていることを見ている。最初 `app/guard.ts:68` の `isAdmin` を壊したが赤くならなかった。Server Action の権限判定は `app/guard.ts` ではなく `app/actions.ts:44-45` の `requireAdmin` にあり、画面側とは別経路だったため。

## 品質ゲート

`server/` で全パス。

```
pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint
Test Files  30 passed (30) / Tests  373 passed (373)
Checked 97 files. No fixes applied.
```

## 直さずに残した指摘

レビューの Minor 3件のうち2件（コメントが指す範囲、`requestHeaders` の差し替えの説明）は直した。残る1件は直していない。

`test/render-page.ts` という名前が中身（サインイン＋描画＋行き先の判定）を言い当てなくなっている。`app/actions.test.ts` は画面を1つも描かないのにここから `signInAs` を取る。ただし分けると1関数だけのファイルが増え、判断1で退けた「置き場を増やす」方向に戻る。名前を変えるだけでも12本の import を書き換えることになるので、実際に詰まるまで置く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC7kw6X1kSvSan6qxjckPa
