### PR TITLE
[test] revalidatePath が呼ばれたかを見る

### DIFF
--- a/server/app/actions.test.ts
+++ b/server/app/actions.test.ts
@@ -123,6 +123,11 @@ const eventFields = {
  * |---|---|
  * | `revalidatePath()` が `redirect()` の後ろへ移る | 行き先の無い1本だけで見た場合 |
  * | `revalidatePath()` が `if (options.redirectTo)` の中へ入る | 行き先のある1本だけで見た場合 |
+ *
+ * `action()` の分かれ道は `adminOnly` と `redirectTo` の2つで、実在する
+ * 組み合わせは3通り。3通り目（`adminOnly` のある削除）は下の
+ * `describe("管理者")` で見る。`revalidated` の2本は管理者ではない人で走るので、
+ * ここには入れられない
  */
 const revalidated = [
   {
@@ -154,18 +159,7 @@ describe("管理者ではない入力者", () => {
   });
 
   it("イベントを登録できる", async () => {
-    expect(
-      await addEvent(
-        null,
-        form({
-          title: "決算発表",
-          shortLabel: "7203決算",
-          startDate: "2026-05-08",
-          importance: "3",
-          target: "stock:1",
-        }),
-      ),
-    ).toBeNull();
+    expect(await addEvent(null, form(eventFields))).toBeNull();
     expect(await db.select().from(event)).toHaveLength(2);
   });
 
@@ -177,16 +171,7 @@ describe("管理者ではない入力者", () => {
       .from(user)
       .where(eq(user.email, EDITOR));
 
-    await addEvent(
-      null,
-      form({
-        title: "決算発表",
-        shortLabel: "7203決算",
-        startDate: "2026-05-08",
-        importance: "3",
-        target: "stock:1",
-      }),
-    );
+    await addEvent(null, form(eventFields));
 
     const rows = await db.select().from(auditLog);
     expect(rows).toHaveLength(1);
@@ -238,5 +223,13 @@ describe("管理者", () => {
     const to = await redirectedTo(() => removeEvent(null, form({ id: "1" })));
     expect(to).toBe("/events");
     expect(await db.select().from(event)).toEqual([]);
+  });
+
+  it("削除でも画面が作り直される", async () => {
+    // `revalidated` の表の3通り目。`adminOnly` の側だけ作り直しを飛ばす壊し方は、
+    // 上の2本では緑のまま通る（Issue #149 で実測）
+    await redirectedTo(() => removeEvent(null, form({ id: "1" })));
+
+    expect(revalidatePath).toHaveBeenCalledWith("/");
   });
 });

--- a/server/app/actions.test.ts
+++ b/server/app/actions.test.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../src/db";
 import {
@@ -31,8 +32,12 @@ import {
 // next/cache も Next.js のリクエストの中でしか動かない。next/headers と
 // ADMIN_EMAIL の差し替えは `test/setup.ts` が全ファイルぶん行うが、これはこの1本
 // でしか要らないのでここに置く（Server Action を直に呼ぶのはこのテストだけ）。
-// vi.mock は import より前に巻き上げられるので、上の import より後に書いてよい
-vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+// vi.mock は import より前に巻き上げられるので、上の import より後に書いてよい。
+//
+// 差し替え先を `() => {}` ではなく `vi.fn()` にしてある。空の関数だと、
+// 呼ばれたことも渡した値も誰も見ないため、`app/actions.ts` から
+// `revalidatePath("/")` を消しても全件が緑のまま通る（Issue #149 で実測）
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 // Server Action を画面を通さず直接呼ぶ（設計書 §4）。画面から削除の欄を消すだけでは、
 // 直接POSTされる経路が塞がっているかを判定できない。
@@ -97,6 +102,45 @@ const adminOnlyDeletes = [
     remaining: () => db.select().from(event),
   },
 ];
+
+/** イベントの入力欄。`id` を足せば編集、足さなければ登録に使える */
+const eventFields = {
+  title: "決算発表",
+  shortLabel: "7203決算",
+  startDate: "2026-05-08",
+  importance: "3",
+  target: "stock:1",
+};
+
+/**
+ * 画面の作り直し（`revalidatePath("/")`）を見る2本。
+ *
+ * 12本すべてが `app/actions.ts` の `action()` を通るので全部を並べる必要は無いが、
+ * **行き先のあるものと無いものは分けて見る。** 片方だけだと、次のどちらかを
+ * 緑のまま通す（どちらも Issue #149 で実測）。
+ *
+ * | 壊し方 | 見逃す側 |
+ * |---|---|
+ * | `revalidatePath()` が `redirect()` の後ろへ移る | 行き先の無い1本だけで見た場合 |
+ * | `revalidatePath()` が `if (options.redirectTo)` の中へ入る | 行き先のある1本だけで見た場合 |
+ */
+const revalidated = [
+  {
+    label: "行き先のある編集",
+    run: () =>
+      redirectedTo(() => editEvent(null, form({ ...eventFields, id: "1" }))),
+  },
+  {
+    label: "行き先の無い登録",
+    run: () => addEvent(null, form(eventFields)),
+  },
+];
+
+// `action()` を通る操作はどれも `revalidatePath()` を呼ぶ。上のテストの呼び出しが
+// 残っていると「このテストで呼ばれた」を見たことにならないので、毎回空にする
+beforeEach(() => {
+  vi.mocked(revalidatePath).mockClear();
+});
 
 describe("管理者ではない入力者", () => {
   beforeEach(async () => {
@@ -173,6 +217,12 @@ describe("管理者ではない入力者", () => {
 
     const [row] = await db.select().from(event);
     expect(row.title).toBe("日銀の金融政策決定会合（変更後）");
+  });
+
+  it.each(revalidated)("$label でも画面が作り直される", async (target) => {
+    await target.run();
+
+    expect(revalidatePath).toHaveBeenCalledWith("/");
   });
 });
 


### PR DESCRIPTION
Closes #149

## 何をしたか

`app/actions.test.ts` が `next/cache` を空の関数に差し替えていたため、`revalidatePath` が呼ばれたかを誰も見ていなかった。`vi.fn()` にして、検査を3件足した。

| 指標 | 前 | 後 |
|---|---|---|
| `next/cache` の差し替え先 | `() => {}` | `vi.fn()` |
| `revalidatePath` を見る検査 | 0件 | 3件 |
| テスト件数 | 373 | 376 |

## 「残る判断」（12本すべてか代表か）

**3件**にした。12本すべてを並べる必要は無いが、**1本では足りない**。

`action()` の分かれ道は `adminOnly` と `redirectTo` の2つで、実在する組み合わせは3通り。壊し方によって落ちる側が違うため、3通りそれぞれに1本ずつ置いた。

| | `redirectTo` なし | `redirectTo` あり |
|---|---|---|
| `adminOnly` なし | 行き先の無い登録（`addEvent`） | 行き先のある編集（`editEvent`） |
| `adminOnly` あり | 該当なし | 削除（`removeEvent`） |

**着手時は代表1本で書いた。レビューで2回穴を指摘され、2回とも実測で再現して埋めた**（下記の変異C・D）。

## 壊して赤くなることの確認

`app/actions.ts` の `action()` を4通りに壊し、全件を流した。

| 変異 | 壊し方 | 落ちる検査 |
|---|---|---|
| A | `revalidatePath("/")` を消す | **3件すべて** |
| B | `redirect()` の後ろへ移す | 行き先のある編集・削除の**2件** |
| C | `if (options.redirectTo)` の中へ入れる | 行き先の無い登録の**1件** |
| D | `if (!options.adminOnly)` で囲う | 削除の**1件** |

A は Issue の受け入れ条件そのもの。B は `redirect()` が例外を投げるので以後 `revalidatePath()` が二度と呼ばれない壊れ方。C は行き先の無い5本（`addStock`・`addTheme`・`addThemeStock`・`addEvent`・`addEvents`）が、D は削除4本が止まる。

**C と D は、着手時の「代表1本」では376件すべて緑のまま通っていた**（どちらも実測）。B と C・D が別々の検査を赤くすることが、3件を置いた根拠。

## 直さずに残した指摘

`app/actions.test.ts:80-82` の既存コメント（`it.each` のタイトル差し込みは英語の欄名しか拾わない）が、今回足した日本語の値と食い違って読めるのではないか、という指摘があった。**直していない。** あのコメントは「欄名」と2度書き、例も `$名前` とキーの側を示している。今回足した `revalidated` もキーは英語（`label`）で値だけが日本語なので、コメントの言うとおりに書いてある。

## 品質ゲート

`server/` で全パス。

```
pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint
Test Files  30 passed (30) / Tests  376 passed (376)
Checked 97 files. No fixes applied.
```

## 着手時に踏んだ落とし穴（記録）

Issue の「検証」を再実行したところ、起票時（373 passed）と一致せず66件赤になった。もう一度流すと71件赤で、**落ちる顔ぶれが実行ごとに変わった**。

原因はコードではなく、メインcheckout `ichikabu/server` で別の vitest（PID 38099）が同時に走り、共有しているテストDBのデータを消し合っていたこと。そのプロセスの終了後、同じコードで373件緑に戻り、検証手順も起票時と一致した。

この Worktree は専用DB（`ichikabu_test_149`）に向けてある。`.env.local` はコミット対象外なので他に影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC7kw6X1kSvSan6qxjckPa
