### PR TITLE
[test] 削除の Server Action に adminOnly が付いているかを見る

### DIFF
--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -65,6 +65,38 @@ const WRITE_IMPORT = /import\s+([^"]*?)\s+from\s+"[^"]*db\/write"/g;
 const DIRECT_WRITE = /\b(?:db|tx)\b\s*\.\s*(?:insert|update|delete|execute)\b/;
 
 /**
+ * `src/db/write.ts` の関数のうち、行を消すもの。**名前ではなく中身で見分ける。**
+ *
+ * 名前の頭が `delete` かで決めると、`deleteTheme` を `purgeTheme` に改名した
+ * だけで見張りが1本黙って減り、その関数を呼ぶ Server Action から
+ * `adminOnly` が落ちても緑のまま通る（実測）。改名は日常の書き直しで起き、
+ * 減ったことは誰にも知らされない。本文の `.delete(` は改名しても残る。
+ * `db` と `tx` の書き方は上の `DIRECT_WRITE` と揃えてある
+ */
+function deleteFunctions(source: string): string[] {
+  return source
+    .split("\nexport ")
+    .slice(1)
+    .filter((block) => /\b(?:db|tx)\s*\.\s*delete\(/.test(block))
+    .map((block) => /function (\w+)/.exec(block)?.[1] ?? "");
+}
+
+/**
+ * `app/actions.ts` の `export const` を1本ずつ、名前と中身の組にして切り出す。
+ *
+ * 終わりを `\n);` で探さない。`addEvents` は `});` で終わるため、そこで閉じずに
+ * 次の `export const` の末尾まで1つの当たりになり、隣の `adminOnly: true` を
+ * 飲み込む（実測）。上の `WRITE_IMPORT` が同じ形の事故を1度踏んでいる。
+ * 次の `export const` までを中身にすれば起きない
+ */
+function exportedActions(source: string): [string, string][] {
+  return source
+    .split("\nexport const ")
+    .slice(1)
+    .map((block) => [block.split(/\W/)[0], block]);
+}
+
+/**
  * 1つの import 文が書き込み関数を値として読み込んでいるかを判定する。
  * `import type { EventInput }` と、`{ type StockInput, createEvent }` の
  * 内側の `type` の両方を落とす
@@ -121,6 +153,39 @@ describe("書き込みの経路", () => {
       .map(([path]) => path);
 
     expect(writers.sort()).toEqual([...ALLOWED_DIRECT_WRITERS].sort());
+  });
+
+  it("削除を呼ぶ Server Action には adminOnly が付いている", () => {
+    // `app/actions.test.ts` は削除4本を名前で並べて「管理者でなければ拒まれる」を
+    // 見ているが、一覧に載っていない5本目が増えたときは何も鳴らない。
+    // 実際、`adminOnly` の無い13本目を足しても全件が緑のまま通った（Issue #150 で実測）。
+    //
+    // ここは動かさずに文字として見る。走らせて見る形（export を全部たどり、
+    // 管理者でない人で叩いて削除が起きないことを見る）も書いて比べたが、
+    // 削除の前に条件がある1本を緑のまま通した（`formData.get("confirm") !== "yes"`
+    // で先に戻る形。実測）。**削除の呼び出しが在ることは、走らせなくても見える。**
+    //
+    // 見ているのは呼び出しが在るかどうかだけで、次の2つは素通りする。
+    // どちらも隣の11本と違う書き方をわざわざ選んだときにしか出ない形で、
+    // このファイルの `DIRECT_WRITE` と同じく**うっかり増えた1本を鳴らすためのもの**。
+    //
+    // | 素通りする書き方 | |
+    // |---|---|
+    // | 削除の中身を `app/actions.ts` の中の別の `const` に出す | 塊の外へ出るため |
+    // | `import { deleteStock as dropStock }` と別名を付ける | 名前が変わるため |
+    const sources = trackedSources();
+
+    // どれが削除かは `src/db/write.ts` から取る。ここに名前を書き写すと、
+    // 削除を1本足す人が書き写しの側も直すことになり、書き忘れで素通りする
+    const deletes = deleteFunctions(sources.get("src/db/write.ts") ?? "");
+    expect(deletes.length).toBeGreaterThan(0);
+
+    const missing = exportedActions(sources.get("app/actions.ts") ?? "")
+      .filter(([, body]) => deletes.some((name) => body.includes(`${name}(`)))
+      .filter(([, body]) => !body.includes("adminOnly: true"))
+      .map(([name]) => name);
+
+    expect(missing).toEqual([]);
   });
 
   it("書き込み関数を呼ぶ2つから record( の呼び出しが消えていない", () => {

--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -65,7 +65,7 @@ const WRITE_IMPORT = /import\s+([^"]*?)\s+from\s+"[^"]*db\/write"/g;
 const DIRECT_WRITE = /\b(?:db|tx)\b\s*\.\s*(?:insert|update|delete|execute)\b/;
 
 /** 削除の呼び出し。取り引きの `tx.delete(...)` も拾う。書き方は `DIRECT_WRITE` と揃える */
-const DELETE_CALL = /\b(?:db|tx)\s*\.\s*delete\(/;
+const DELETE_CALL = /\b(?:db|tx)\b\s*\.\s*delete\(/;
 
 /**
  * ファイルの `export` を1本ずつ、名前と中身の組にして切り出す。
@@ -78,7 +78,10 @@ const DELETE_CALL = /\b(?:db|tx)\s*\.\s*delete\(/;
  *
  * 名前は先頭でだけ探す。どこでもよいことにすると、アロー関数で書いた
  * `export const` から、その後ろに続く別の関数の名前を拾う（実測）。
- * 型の export（`export type`）は名前が取れないので落ちる
+ * `function` か `const` の名前で始まらない export（`export type` 等）は落ちる。
+ *
+ * export と export のあいだに置いた非公開の関数は、**手前の export の中身**
+ * として数える（`src/db/write.ts` の `activeEntries` が実際にその位置にある）
  */
 function exportedBlocks(source: string): [string, string][] {
   return source
@@ -166,6 +169,7 @@ describe("書き込みの経路", () => {
     // | 素通りする書き方 | 理由 |
     // |---|---|
     // | 削除の中身を `app/actions.ts` の中の別の `const` に出す | 塊の外へ出る |
+    // | 削除の中身を `src/db/write.ts` の非公開の関数に出す | 同上 |
     // | `import { deleteStock as dropStock }` と別名を付ける | 名前が変わる |
     // | `src/db/write.ts` で取り引きの引数を `tx` 以外の名前にする | `DELETE_CALL` が拾わない |
     //

--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -64,36 +64,30 @@ const WRITE_IMPORT = /import\s+([^"]*?)\s+from\s+"[^"]*db\/write"/g;
  */
 const DIRECT_WRITE = /\b(?:db|tx)\b\s*\.\s*(?:insert|update|delete|execute)\b/;
 
+/** 削除の呼び出し。取り引きの `tx.delete(...)` も拾う。書き方は `DIRECT_WRITE` と揃える */
+const DELETE_CALL = /\b(?:db|tx)\s*\.\s*delete\(/;
+
 /**
- * `src/db/write.ts` の関数のうち、行を消すもの。**名前ではなく中身で見分ける。**
+ * ファイルの `export` を1本ずつ、名前と中身の組にして切り出す。
+ * 中身は、次の `export` の手前までの一続きの文字列。
  *
- * 名前の頭が `delete` かで決めると、`deleteTheme` を `purgeTheme` に改名した
- * だけで見張りが1本黙って減り、その関数を呼ぶ Server Action から
- * `adminOnly` が落ちても緑のまま通る（実測）。改名は日常の書き直しで起き、
- * 減ったことは誰にも知らされない。本文の `.delete(` は改名しても残る。
- * `db` と `tx` の書き方は上の `DIRECT_WRITE` と揃えてある
+ * 終わりを `\n);` で探さない。`app/actions.ts` の `addEvents` は `});` で
+ * 終わるため、そこで閉じずに次の `export` の末尾まで1つの当たりになり、
+ * 隣の `adminOnly: true` を飲み込む（実測）。上の `WRITE_IMPORT` が
+ * 同じ形の事故を1度踏んでいる。
+ *
+ * 名前は先頭でだけ探す。どこでもよいことにすると、アロー関数で書いた
+ * `export const` から、その後ろに続く別の関数の名前を拾う（実測）。
+ * 型の export（`export type`）は名前が取れないので落ちる
  */
-function deleteFunctions(source: string): string[] {
+function exportedBlocks(source: string): [string, string][] {
   return source
     .split("\nexport ")
     .slice(1)
-    .filter((block) => /\b(?:db|tx)\s*\.\s*delete\(/.test(block))
-    .map((block) => /function (\w+)/.exec(block)?.[1] ?? "");
-}
-
-/**
- * `app/actions.ts` の `export const` を1本ずつ、名前と中身の組にして切り出す。
- *
- * 終わりを `\n);` で探さない。`addEvents` は `});` で終わるため、そこで閉じずに
- * 次の `export const` の末尾まで1つの当たりになり、隣の `adminOnly: true` を
- * 飲み込む（実測）。上の `WRITE_IMPORT` が同じ形の事故を1度踏んでいる。
- * 次の `export const` までを中身にすれば起きない
- */
-function exportedActions(source: string): [string, string][] {
-  return source
-    .split("\nexport const ")
-    .slice(1)
-    .map((block) => [block.split(/\W/)[0], block]);
+    .flatMap((block) => {
+      const name = /^(?:async )?(?:function|const) (\w+)/.exec(block)?.[1];
+      return name ? [[name, block] as [string, string]] : [];
+    });
 }
 
 /**
@@ -165,22 +159,32 @@ describe("書き込みの経路", () => {
     // 削除の前に条件がある1本を緑のまま通した（`formData.get("confirm") !== "yes"`
     // で先に戻る形。実測）。**削除の呼び出しが在ることは、走らせなくても見える。**
     //
-    // 見ているのは呼び出しが在るかどうかだけで、次の2つは素通りする。
-    // どちらも隣の11本と違う書き方をわざわざ選んだときにしか出ない形で、
-    // このファイルの `DIRECT_WRITE` と同じく**うっかり増えた1本を鳴らすためのもの**。
+    // 見ているのは呼び出しが在るかどうかだけで、次の3つは素通りする。
+    // `DIRECT_WRITE` と同じく**うっかり増えた1本を鳴らすためのもの**で、
+    // 意図して避ける相手を止めるものではない。
     //
-    // | 素通りする書き方 | |
+    // | 素通りする書き方 | 理由 |
     // |---|---|
-    // | 削除の中身を `app/actions.ts` の中の別の `const` に出す | 塊の外へ出るため |
-    // | `import { deleteStock as dropStock }` と別名を付ける | 名前が変わるため |
+    // | 削除の中身を `app/actions.ts` の中の別の `const` に出す | 塊の外へ出る |
+    // | `import { deleteStock as dropStock }` と別名を付ける | 名前が変わる |
+    // | `src/db/write.ts` で取り引きの引数を `tx` 以外の名前にする | `DELETE_CALL` が拾わない |
+    //
+    // `adminOnly: true` は直に書く。`adminOnly: ADMIN` のように変数で渡すと、
+    // 正しく限っていてもここが赤くなる
     const sources = trackedSources();
 
-    // どれが削除かは `src/db/write.ts` から取る。ここに名前を書き写すと、
-    // 削除を1本足す人が書き写しの側も直すことになり、書き忘れで素通りする
-    const deletes = deleteFunctions(sources.get("src/db/write.ts") ?? "");
+    // どれが削除かは `src/db/write.ts` の本文から取る。**名前では決めない。**
+    // 名前の頭が `delete` かで決めると、`deleteTheme` を `purgeTheme` に改名した
+    // だけで見張りが1本黙って減り、その関数を呼ぶ Server Action から `adminOnly`
+    // が落ちても緑のまま通る（実測）。改名は日常の書き直しで起き、減ったことは
+    // 誰にも知らされない。本文の `.delete(` は改名しても残る。
+    // ここに名前を書き写す形にしないのも同じ理由で、書き写しの側を直し忘れる
+    const deletes = exportedBlocks(sources.get("src/db/write.ts") ?? "")
+      .filter(([, body]) => DELETE_CALL.test(body))
+      .map(([name]) => name);
     expect(deletes.length).toBeGreaterThan(0);
 
-    const missing = exportedActions(sources.get("app/actions.ts") ?? "")
+    const missing = exportedBlocks(sources.get("app/actions.ts") ?? "")
       .filter(([, body]) => deletes.some((name) => body.includes(`${name}(`)))
       .filter(([, body]) => !body.includes("adminOnly: true"))
       .map(([name]) => name);


### PR DESCRIPTION
Closes #150

`app/actions.test.ts` は削除4本を名前で並べて「管理者でなければ拒まれる」を見ているため、一覧に載っていない5本目が増えたときは何も鳴らない。`adminOnly` の無い13本目を足しても376件すべてが緑のまま通った（起票時と着手時の両方で実測）。

`src/db/write-boundary.test.ts` に1本足し、`app/actions.ts` の export を1本ずつ切り出して、削除を呼ぶのに `adminOnly: true` の無いものを名指しする。

## 受け入れ条件

Issue の「検証」の手順を再実行した結果:

```
 FAIL  src/db/write-boundary.test.ts > 書き込みの経路 > 削除を呼ぶ Server Action には adminOnly が付いている
      Tests  1 failed | 376 passed (377)
```

Issue の「あるべき姿の出力」は落ちるファイルを `app/actions.test.ts` と書いていたが、Issue 自身が先例として挙げた `src/db/write-boundary.test.ts` に置いた。件数の形（1 failed | 376 passed）は一致している。

品質ゲート（`pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint`）は全部通る。377 passed、lint 0件。

## 見つけ方を決めた経緯

Issue の「残る判断」（文字として見る／走らせて見る）は、**両方を実際に書いて13本目の書き方ごとに流して**決めた。○が赤くなる、×が素通り。

| 13本目の書き方 | 文字として見る | 走らせて見る |
|---|---|---|
| 末尾に素直に足す | ○ | ○ |
| `});` で終わるブロック形式を `adminOnly` 付きの隣に置く | ○ | ○ |
| 新しい欄名（`eventId` 等）を読む | ○ | ×（`get` を全部 "1" で返す形に直せば○） |
| 削除の中身を別の `const` に出す | × | ○ |
| `src/db/write.ts` の削除関数を改名 + `adminOnly` 落ち | ○ | ○ |
| **削除の前に条件がある**（`get("confirm") !== "yes"` で先に戻る） | ○ | **×** |

決め手は最後の行。走らせて見る形は「実際に行が消えたか」を見るので、条件で手前に戻る削除は永久に緑になる。**削除の呼び出しが在ることは、走らせなくても見える。** 加えて、走らせて見る形は12本ぶんのDBの往復で全体が3.5秒延び、文字として見る形は22ミリ秒で済む。

どれが削除かは `src/db/write.ts` の本文の `.delete(` で決める。名前の頭が `delete` かで決めると、`deleteTheme` を `purgeTheme` に改名しただけで見張りが1本黙って減り、その関数を呼ぶ Server Action から `adminOnly` が落ちても緑のまま通った（実測）。

塊の切り出しは `split("\nexport ")` で行う。`/export const (\w+) = action\(([\s\S]*?)\n\);/` のような非貪欲マッチは、`});` で終わる `addEvents` でそこで閉じず隣の `adminOnly: true` を飲み込む。同じ形の事故を、このファイルの `WRITE_IMPORT` が1度踏んでいる。

## レビューで直したこと

すべて、書き換えて流して確かめた。

| 直したもの | 直す前 |
|---|---|
| `export async function` で書いた13本目 | 素通り。`export const` しか切り出していなかった |
| `src/db/write.ts` の削除をアロー関数に書き換える | その1本が見張りから落ちる。名前を塊のどこでも探し、後ろの別の関数名を拾っていた |
| 名前が取れなかったときの空文字 | `body.includes("(")` になり、12本すべてが削除を呼ぶ扱いになる誤検出 |

## 直さずに残したもの

**素通りする形が4つ残る。** どれもコメントの表に書いてある。`DIRECT_WRITE` と同じく、うっかり増えた1本を鳴らすためのもので、意図して避ける相手を止めるものではない。

- 削除の中身を `app/actions.ts` の中の別の `const` に出す
- 削除の中身を `src/db/write.ts` の非公開の関数に出す
- `import { deleteStock as dropStock }` と別名を付ける
- `src/db/write.ts` で取り引きの引数を `tx` 以外の名前にする

**誤検出が2つ残る。** どちらも今の書き方では出ない。塞ぐには本物の解析が要るため、コメントに書いて残した。

- `adminOnly: true` を変数で渡す（`adminOnly: ADMIN`）
- export と export のあいだに削除のヘルパーを置くと、手前の export が削除として数えられる

**`app/actions.ts` 側の空チェックは足していない。** ファイル名が動けば隣の `it`（`ALLOWED` との突き合わせ）が赤くなるため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC7kw6X1kSvSan6qxjckPa
