### PR TITLE
[test] サインインしていない人が Server Action を叩いたときを見る

### DIFF
--- a/server/app/actions.test.ts
+++ b/server/app/actions.test.ts
@@ -20,6 +20,7 @@ import {
 import { resetDatabase } from "../test/helpers";
 import { eventInput, stockInput } from "../test/inputs";
 import { PASSWORD, redirectedTo, signInAs } from "../test/render-page";
+import { requestHeaders } from "../test/setup";
 import {
   addEvent,
   editEvent,
@@ -141,6 +142,33 @@ const revalidated = [
   },
 ];
 
+/**
+ * サインインしていない人が Server Action を直に叩いたときの2本。
+ *
+ * **`action()` のセッションの取り方は2通りあり、どちらも見る。** `adminOnly` の
+ * ある削除は `requireSession()` を、無いほうは `requireUserId()` を通る。片方だけ
+ * だと、もう片方の壊し方を緑のまま通す（3通りとも実測。→ Issue #147）。
+ *
+ * | 壊し方 | 削除 | 登録 |
+ * |---|---|---|
+ * | `app/guard.ts` の `requireSession` から `redirect("/signin")` を外す | 赤 | 赤 |
+ * | `requireUserId` が `requireSession` を通らなくなる | **緑** | 赤 |
+ * | `adminOnly` の分岐が `requireSession` を通らなくなる | 赤 | **緑** |
+ *
+ * 削除の対象は作らない。追い返されるところまでしか進まないため、
+ * 何が在るかは結果に効かない
+ */
+const unauthenticated = [
+  {
+    label: "削除",
+    run: () => removeEvent(null, form({ id: "1" })),
+  },
+  {
+    label: "登録",
+    run: () => addEvent(null, form(eventFields)),
+  },
+];
+
 // `action()` を通る操作はどれも `revalidatePath()` を呼ぶ。上のテストの呼び出しが
 // 残っていると「このテストで呼ばれた」を見たことにならないので、毎回空にする
 beforeEach(() => {
@@ -232,4 +260,21 @@ describe("管理者", () => {
 
     expect(revalidatePath).toHaveBeenCalledWith("/");
   });
+});
+
+describe("サインインしていない人", () => {
+  // `signInAs` を呼ばないので、1つ上のテストが入れた Cookie がそのまま残る。
+  // 空の Headers に戻して、サインインしていない状態を作る（`test/setup.ts`）
+  beforeEach(() => {
+    requestHeaders.current = new Headers();
+  });
+
+  it.each(unauthenticated)(
+    "$label を直に叩くとサインインの画面へ送られる",
+    async (target) => {
+      // 行き先まで見る。`redirect()` が起きたことだけを見ると、削除の成功も
+      // 同じ `NEXT_REDIRECT` なので見分けられない（`test/render-page.ts`）
+      expect(await redirectedTo(target.run)).toBe("/signin");
+    },
+  );
 });

--- a/server/app/actions.test.ts
+++ b/server/app/actions.test.ts
@@ -155,8 +155,8 @@ const revalidated = [
  * | `requireUserId` が `requireSession` を通らなくなる | **緑** | 赤 |
  * | `adminOnly` の分岐が `requireSession` を通らなくなる | 赤 | **緑** |
  *
- * 削除の対象は作らない。追い返されるところまでしか進まないため、
- * 何が在るかは結果に効かない
+ * 削除の対象は作らない。行き先だけを見る。追い返されずに書き込みまで進む
+ * 壊れ方は、`adminOnlyDeletes` の `remaining()` と監査ログの1本が既に見ている
  */
 const unauthenticated = [
   {
@@ -264,7 +264,9 @@ describe("管理者", () => {
 
 describe("サインインしていない人", () => {
   // `signInAs` を呼ばないので、1つ上のテストが入れた Cookie がそのまま残る。
-  // 空の Headers に戻して、サインインしていない状態を作る（`test/setup.ts`）
+  // `resetDatabase()` が session の行も消すため、残っていてもセッションは引けないが、
+  // 「サインインしていない」を読み手に見せるために空の Headers を入れる
+  // （`test/setup.ts`。`test/pages.test.ts` も同じ書き方）
   beforeEach(() => {
     requestHeaders.current = new Headers();
   });

--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -196,6 +196,37 @@ describe("書き込みの経路", () => {
     expect(missing).toEqual([]);
   });
 
+  it("Server Action はどれもサインインの判定を通る", () => {
+    // `app/actions.test.ts` は代表2本で「サインインしていないと追い返される」を
+    // 見ているが、その2本は `action()` を通る道しか通らない。`action()` を通らない
+    // 13本目が増えても何も鳴らない（判定も記録もしない1本を足して全379件が緑の
+    // まま通った。Issue #147 で実測）。既存の1本が `action()` を外れた場合も同じで、
+    // `editStock` を手書きに直すと画面と Server Action の68件すべてが緑だった。
+    //
+    // ここは1つ上の `adminOnly` の検査と違い、export を塊に切り出さず**行で見る**。
+    // 塊に切り出す `exportedBlocks` は名前を取れない export を黙って捨てるため、
+    // `export default async function` の13本目が素通りする（実測）。行で見て
+    // 「形の合わない export を挙げる」にすると、知らない書き方ほど赤くなる。
+    //
+    // | 足したもの | 結果 |
+    // |---|---|
+    // | `export default async function purgeEvent(` | 赤 |
+    // | `export { removeEvent as purgeEvent };` | 赤 |
+    // | `export const editStock = async (` | 赤 |
+    //
+    // **再輸出（`export { removeEvent as purgeEvent };`）も名指す。** 中身は
+    // `action()` を通っているので、これは正しいものを赤くする側の間違い。
+    // 害が無いので受け入れる（今そう書いた行は1つも無い）。踏んだら、
+    // 再輸出をやめるか、ここに逃がす形を決める
+    const lines =
+      (trackedSources().get("app/actions.ts") ?? "").match(/^export .*/gm) ?? [];
+    expect(lines.length).toBeGreaterThan(0);
+
+    expect(
+      lines.filter((line) => !/^export const \w+ = action\(/.test(line)),
+    ).toEqual([]);
+  });
+
   it("書き込み関数を呼ぶ2つから record( の呼び出しが消えていない", () => {
     // 呼べる場所を絞っても、そこで record() を呼ばなければ記録は残らない。
     // scripts/import-stat-schedule.ts はテストから叩けない（読み込んだ時点で

--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -78,9 +78,21 @@ const EXPORT_LINE = /^export .*/gm;
 
 /**
  * サインインの判定を通す Server Action の書き方。
- * `app/actions.ts` の12本はどれも1行目がこの形で、`action()` が判定を運ぶ
+ * `app/actions.ts` の12本はどれも `export` の行がこの形で、`action()` が判定を運ぶ
  */
 const GUARDED_EXPORT = /^export const \w+ = action\(/;
+
+/**
+ * Server Action のファイルの目印。
+ *
+ * ファイルの先頭を見る形（`startsWith`）にしない。ディレクティブの前に
+ * コメントを置くのは正しい書き方で、このリポジトリは先頭が説明のコメントの
+ * ファイルが普通（`src/admin.ts`）。先頭を見る形だと、そう書いた2つ目の
+ * Server Action のファイルを1行も読まない（実測）。
+ *
+ * コメントの中の `"use server"` は、行頭でも `";` 終わりでもないので拾わない
+ */
+const SERVER_DIRECTIVE = /^"use server";$/m;
 
 /**
  * ファイルの `export` を1本ずつ、名前と中身の組にして切り出す。
@@ -233,14 +245,21 @@ describe("書き込みの経路", () => {
     //
     // | 書き方 | どうなるか |
     // |---|---|
-    // | 関数の中に `"use server"` を書いて1つの関数だけ Server Action にする | 素通りする（ファイルの1行目を見るため） |
+    // | 関数の中に `"use server"` を書いて1つの関数だけ Server Action にする | 素通りする（行頭のディレクティブを見るため） |
     // | 別名を付けて出し直す `export { removeEvent as purgeEvent };` | 正しいのに赤くなる |
     // | `export type` を足す | 同上（今 `app/actions.ts` に公開している型は無い） |
+    // | Server Action を2つ目のファイルに置く | そのファイルごと赤くなる |
     //
-    // 正しいのに赤くなる2つは、今そう書いた行が1つも無いので受け入れる。
-    // 踏んだら、その書き方をやめるか、ここに逃がす形を決める
+    // 最後の1つは、この検査が実質「Server Action は `app/actions.ts` にしか
+    // 置けない」を固定していることによる。`action()` は `app/actions.ts` の
+    // 非公開の関数で、`app/guard.ts` へは出せない（理由は `app/actions.ts` の
+    // `action()` のコメント）。1つのファイルに寄せる方針そのものなので、
+    // 2つ目のファイルが要るようになったら、そのとき置き場所から決める
+    //
+    // 上の2つ（別名を付けて出し直す形・`export type`）は、今そう書いた行が
+    // 1つも無いので受け入れる。踏んだら、その書き方をやめるか、ここに逃がす形を決める
     const files = [...trackedSources()].filter(([, source]) =>
-      source.startsWith('"use server"'),
+      SERVER_DIRECTIVE.test(source),
     );
     expect(files.length).toBeGreaterThan(0);
 

--- a/server/src/db/write-boundary.test.ts
+++ b/server/src/db/write-boundary.test.ts
@@ -68,6 +68,21 @@ const DIRECT_WRITE = /\b(?:db|tx)\b\s*\.\s*(?:insert|update|delete|execute)\b/;
 const DELETE_CALL = /\b(?:db|tx)\b\s*\.\s*delete\(/;
 
 /**
+ * ファイルの `export` の行。行の途中に現れる `export` は拾わない。
+ *
+ * 塊に切り出す `exportedBlocks` は使わない。あちらは名前を取れない export を
+ * 黙って捨てるため、`export default async function` の Server Action が
+ * 素通りする（実測）
+ */
+const EXPORT_LINE = /^export .*/gm;
+
+/**
+ * サインインの判定を通す Server Action の書き方。
+ * `app/actions.ts` の12本はどれも1行目がこの形で、`action()` が判定を運ぶ
+ */
+const GUARDED_EXPORT = /^export const \w+ = action\(/;
+
+/**
  * ファイルの `export` を1本ずつ、名前と中身の組にして切り出す。
  * 中身は、次の `export` の手前までの一続きの文字列。
  *
@@ -196,17 +211,16 @@ describe("書き込みの経路", () => {
     expect(missing).toEqual([]);
   });
 
-  it("Server Action はどれもサインインの判定を通る", () => {
+  it("Server Action はどれも action() を通る", () => {
     // `app/actions.test.ts` は代表2本で「サインインしていないと追い返される」を
     // 見ているが、その2本は `action()` を通る道しか通らない。`action()` を通らない
-    // 13本目が増えても何も鳴らない（判定も記録もしない1本を足して全379件が緑の
-    // まま通った。Issue #147 で実測）。既存の1本が `action()` を外れた場合も同じで、
-    // `editStock` を手書きに直すと画面と Server Action の68件すべてが緑だった。
+    // 13本目が増えても、その2本は鳴らない（判定も記録もしない1本を足したところ、
+    // 画面と Server Action の68件すべてが緑のまま通った。Issue #147 で実測）。
+    // 既存の1本が `action()` を外れた場合も同じで、`editStock` を手書きに直しても
+    // 同じ68件が緑だった。
     //
-    // ここは1つ上の `adminOnly` の検査と違い、export を塊に切り出さず**行で見る**。
-    // 塊に切り出す `exportedBlocks` は名前を取れない export を黙って捨てるため、
-    // `export default async function` の13本目が素通りする（実測）。行で見て
-    // 「形の合わない export を挙げる」にすると、知らない書き方ほど赤くなる。
+    // 見るのは `"use server"` で始まるファイル全部。`app/actions.ts` と書き写すと、
+    // Server Action を置いた2つ目のファイルが増えたとき1行も読まない。
     //
     // | 足したもの | 結果 |
     // |---|---|
@@ -214,17 +228,29 @@ describe("書き込みの経路", () => {
     // | `export { removeEvent as purgeEvent };` | 赤 |
     // | `export const editStock = async (` | 赤 |
     //
-    // **再輸出（`export { removeEvent as purgeEvent };`）も名指す。** 中身は
-    // `action()` を通っているので、これは正しいものを赤くする側の間違い。
-    // 害が無いので受け入れる（今そう書いた行は1つも無い）。踏んだら、
-    // 再輸出をやめるか、ここに逃がす形を決める
-    const lines =
-      (trackedSources().get("app/actions.ts") ?? "").match(/^export .*/gm) ?? [];
-    expect(lines.length).toBeGreaterThan(0);
+    // 素通りするもの・正しいのに赤くなるものは次のとおり。`DIRECT_WRITE` と同じく
+    // **うっかり増えた1本を鳴らすためのもの**で、意図して避ける相手を止めるものではない。
+    //
+    // | 書き方 | どうなるか |
+    // |---|---|
+    // | 関数の中に `"use server"` を書いて1つの関数だけ Server Action にする | 素通りする（ファイルの1行目を見るため） |
+    // | 別名を付けて出し直す `export { removeEvent as purgeEvent };` | 正しいのに赤くなる |
+    // | `export type` を足す | 同上（今 `app/actions.ts` に公開している型は無い） |
+    //
+    // 正しいのに赤くなる2つは、今そう書いた行が1つも無いので受け入れる。
+    // 踏んだら、その書き方をやめるか、ここに逃がす形を決める
+    const files = [...trackedSources()].filter(([, source]) =>
+      source.startsWith('"use server"'),
+    );
+    expect(files.length).toBeGreaterThan(0);
 
-    expect(
-      lines.filter((line) => !/^export const \w+ = action\(/.test(line)),
-    ).toEqual([]);
+    const notGuarded = files.flatMap(([path, source]) =>
+      (source.match(EXPORT_LINE) ?? [])
+        .filter((line) => !GUARDED_EXPORT.test(line))
+        .map((line) => `${path}: ${line}`),
+    );
+
+    expect(notGuarded).toEqual([]);
   });
 
   it("書き込み関数を呼ぶ2つから record( の呼び出しが消えていない", () => {


### PR DESCRIPTION
Closes #147

サインインしていない状態で Server Action を直に叩いたとき追い返されることを、テストで見ていなかった。`app/guard.ts` の `requireSession` から `redirect("/signin")` を外しても、赤くなるのは画面の9件だけで `app/actions.test.ts` は1件も落ちなかった。

## 入れたもの

| 場所 | 中身 |
|---|---|
| `app/actions.test.ts` | 代表2本。空の `Headers` で `removeEvent` と `addEvent` を直に呼び、`redirect()` の行き先が `/signin` であることを見る |
| `src/db/write-boundary.test.ts` | 1本。`"use server"` のファイルの `export` 行がどれも `export const <名前> = action(` の形かを、文字として見る |

実装コードは1行も変えていない。

## 「12本すべてか、代表1本か」の判断

Issue の「残る判断」を、別の文脈のエージェント2体の討論と実測で決めた。結論は**代表2本＋静的検査1本**。討論は3ラウンドで、代表だけで足りるとしていた側が最終ラウンドで静的検査を入れる側に回って収束した。

**代表1本では足りない。** `action()` のセッションの取り方は2通り（`adminOnly` の削除は `requireSession()`、それ以外は `requireUserId()`）あり、片方だけだともう片方の壊し方を緑のまま通す。

**代表2本でも足りない。** その2本は `action()` を通る道しか通らないため、`action()` を通らない13本目が増えても鳴らない。

**12本すべてに足す案は落とした。** 分岐は `adminOnly` の1つだけで2本が尽くしており、13本目には届かない。静的検査が捕まえる範囲の内側に留まる。

**Issue 本文が代表案の前提にした条件は満たされなかった。** 本文は「#150 の形が全12本の判定の通り方まで見られるなら代表1本で足りる」と書いていたが、#150 で入ったのは「削除を呼ぶ export に `adminOnly: true` があるか」だけで、`action()` を通っているかは見ていない（実測）。

## 壊して赤くなることの実測

| 壊し方 | 代表2本 | 静的検査 |
|---|---|---|
| `requireSession` から `redirect("/signin")` を外す | 赤2件 | 緑 |
| `requireUserId` が `requireSession` を通らなくなる | 赤（登録のみ） | 緑 |
| `adminOnly` の分岐が `requireSession` を通らなくなる | 赤（削除のみ） | 緑 |
| `action()` を通らない13本目を足す（登録だけ） | 緑 | 赤 |
| `export default async function` の13本目 | 緑 | 赤 |
| `export { removeEvent as purgeEvent };` | 緑 | 赤 |
| 既存の `editStock` が `action()` を外れる | 緑 | 赤 |
| Server Action を2つ目のファイルに置く | 緑 | 赤 |

上の3行と下の5行で赤くなる側が分かれる。どちらも欠けない。

## 受け入れ条件

- [x] 「検証」の手順を再実行すると `FAIL app/actions.test.ts` と `FAIL test/pages.test.ts` の両方が出る
- [x] `pnpm test:run` の件数が増えている（377 → 380）
- [x] `pnpm install && pnpm gen && pnpm build && pnpm test:run && pnpm typecheck && pnpm lint` が全部通る（warning も0件）

**Issue 本文の「あるべき姿の出力」の数字は着地しない。** 本文は `10 failed | 366 passed (376)` だが、実測は `11 failed | 369 passed (380)`。ずれの内訳は次のとおりで、`FAIL` の2ファイルが出る点は満たしている。

| | 総数 |
|---|---|
| Issue 起票時（2026-09-04） | 376 |
| このブランチの起点 | 377（#154 で `adminOnly` の検査が1本増えた） |
| このPR | 380（代表2本＋静的検査1本） |

## 残した見逃し・正しいのに赤くなるもの

静的検査は `DIRECT_WRITE` と同じく**うっかり増えた1本を鳴らすためのもの**で、意図して避ける相手を止めるものではない。素通りするもの（関数の中に `"use server"` を書く形）と、正しいのに赤くなるもの（別名を付けて出し直す形・`export type`・2つ目のファイル）をテストのコメントに表で書き残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC7kw6X1kSvSan6qxjckPa
